### PR TITLE
Implement Wrapper Component

### DIFF
--- a/src/main/webapp/components/Wrapper.js
+++ b/src/main/webapp/components/Wrapper.js
@@ -1,0 +1,9 @@
+import * as React from "react";
+ 
+export const Wrapper = (props) => {
+  return (
+    <div>
+      {props.children}
+    </div>
+  )
+}

--- a/src/main/webapp/components/Wrapper.js
+++ b/src/main/webapp/components/Wrapper.js
@@ -1,8 +1,10 @@
 import * as React from "react";
- 
+import {getField} from "utils/getField";
+
 export const Wrapper = (props) => {
+  const className = getField(props,"className","");
   return (
-    <div>
+    <div className={className}>
       {props.children}
     </div>
   )

--- a/src/main/webapp/components/Wrapper.js
+++ b/src/main/webapp/components/Wrapper.js
@@ -7,5 +7,5 @@ export const Wrapper = (props) => {
     <div className={className}>
       {props.children}
     </div>
-  )
+  );
 }

--- a/src/main/webapp/components/Wrapper.js
+++ b/src/main/webapp/components/Wrapper.js
@@ -1,6 +1,14 @@
 import * as React from "react";
 import {getField} from "utils/getField";
 
+/**
+  * Container element used to wrap DOM elements.
+  * Used as a abstraction for "div" HTML element.
+  * 
+  * @param props an object specifying the child components
+  * and optionally specifying a className.
+  *
+*/
 export const Wrapper = (props) => {
   const className = getField(props,"className","");
   return (


### PR DESCRIPTION
This PR implements a helper class used in various places to wrap related components. 
The **Wrapper** class is a simple, class-customisable div container.

It is used to abstract away the HTML div element, and structurally clean up the React Components. 

_Relies on a helper, getField, that will be integrated in a future PR. getField is a method used to get a value from an object or give a defaultValue if that value is undefined._