### PR TITLE
Include Field Getter Utilities in new folder, /components/utils

### DIFF
--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -1,0 +1,1 @@
+export const getField = (obj, field, defaultValue) => obj[field] !== undefined ? obj[field] : (defaultValue !== undefined ? defaultValue : null);

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -1,7 +1,6 @@
 /**
-  * Returns the value at obj[field] or defaultValue
-  * if obj[field] === undefined.
-  * Useful for extracting a field from an object, with a fallback.
+  * Useful for extracting a field from an object, with a fallback (defaultValue).
+  * Useful where "undefined", is not a desired result for a missing field.
   *
   * @param obj the object to query the fields for.
   * @param field the target field, in string form. 

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -7,6 +7,7 @@
   * @param field the target field, in string form. 
   * @param defaultValue the value to be used if obj[field] === undefined.
  */
-export const getField = (obj, field, defaultValue) => obj[field] !== undefined
-? obj[field]
-: (defaultValue !== undefined ? defaultValue : null);
+export const getField = (obj, field, defaultValue) => {
+  return obj[field] !== undefined ?
+  obj[field] : (defaultValue !== undefined ? defaultValue : null);
+}

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -1,12 +1,13 @@
 /**
-  * Useful for extracting a field from an object, with a fallback (defaultValue).
-  * Useful where "undefined", is not a desired result for a missing field.
-  *
-  * @param obj the object to query the fields for.
-  * @param field the target field, in string form. 
-  * @param defaultValue the value to be used if obj[field] === undefined.
+ * Useful for extracting a field from an object, with a fallback (defaultValue).
+ * Useful where "undefined", is not a desired result for a missing field.
+ *
+ * @param obj the object to query the fields for.
+ * @param field the target field, in string form.
+ * @param defaultValue the value to be used if obj[field] === undefined.
  */
 export const getField = (obj, field, defaultValue) => {
   return obj[field] !== undefined ?
-  obj[field] : (defaultValue !== undefined ? defaultValue : null);
+      obj[field] :
+      (defaultValue !== undefined ? defaultValue : null);
 }

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -6,4 +6,6 @@
   * @param field the target field, in string form. 
   * @param defaultValue the value to be used if obj[field] === undefined.
  */
-export const getField = (obj, field, defaultValue) => obj[field] !== undefined ? obj[field] : (defaultValue !== undefined ? defaultValue : null);
+export const getField = (obj, field, defaultValue) => obj[field] !== undefined
+? obj[field]
+: (defaultValue !== undefined ? defaultValue : null);

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -1,5 +1,6 @@
 /**
-  * Returns the value at obj[field] or defaultValue if obj[field] === undefined.
+  * Returns the value at obj[field] or defaultValue
+  * if obj[field] === undefined.
   * Useful for extracting a field from an object, with a fallback.
   *
   * @param obj the object to query the fields for.

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -1,1 +1,9 @@
+/**
+  * Returns the value at obj[field] or defaultValue if obj[field] === undefined.
+  * Useful for extracting a field from an object, with a fallback.
+  *
+  * @param obj the object to query the fields for.
+  * @param field the target field, in string form. 
+  * @param defaultValue the value to be used if obj[field] === undefined.
+ */
 export const getField = (obj, field, defaultValue) => obj[field] !== undefined ? obj[field] : (defaultValue !== undefined ? defaultValue : null);

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -11,6 +11,8 @@ import {getField} from "./getField";
  */
 export const getFields = (obj, fields, defaultValue) => {
   const res = {};
-  for (const field of fields) { res[field] = getField(obj, field, defaultValue); }
+  for (const field of fields) { 
+    res[field] = getField(obj, field, defaultValue);
+  }
   return res;
 }

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -9,7 +9,7 @@ import {getField} from "./getField";
   * @param defaultValue the value to be used if obj[field] === undefined.
  */
 export const getFields = (obj, fields, defaultValue) => {
-  const result = {};
-  for (const field of fields) result[field] = getField(obj, field, defaultValue);
-  return result;
+  const res = {};
+  for (const field of fields) res[field] = getField(obj, field, defaultValue);
+  return res;
 }

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -11,6 +11,6 @@ import {getField} from "./getField";
  */
 export const getFields = (obj, fields, defaultValue) => {
   const res = {};
-  for (const field of fields) res[field] = getField(obj, field, defaultValue);
+  for (const field of fields) { res[field] = getField(obj, field, defaultValue); }
   return res;
 }

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -6,7 +6,7 @@ import {getField} from "./getField";
   * Useful for extracting a subset of fields from an object.
   *
   * @param obj the object to query the fields for.
-  * @param fields an array of the target fields, in string form. 
+  * @param fields an array of the target fields, in string form.
   * @param defaultValue the value to be used if obj[field] === undefined.
  */
 export const getFields = (obj, fields, defaultValue) => {

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -1,3 +1,11 @@
+/**
+  * Creates a new object whose fields are either equal to obj[field] or defaultValue.
+  * Useful for extracting a subset of fields from an object.
+  *
+  * @param obj the object to query the fields for.
+  * @param fields an array of the target fields, in string form. 
+  * @param defaultValue 
+ */
 const getFields = (obj, fields, defaultValue) => {
   const result = { };
   for(const field of fields) result[field] = getField(obj, field, defaultValue);

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -1,3 +1,5 @@
+import {getField} from "./getField";
+
 /**
   * Creates a new object whose fields are either equal to obj[field] or defaultValue.
   * Useful for extracting a subset of fields from an object.

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -9,7 +9,7 @@ import {getField} from "./getField";
   * @param defaultValue the value to be used if obj[field] === undefined.
  */
 export const getFields = (obj, fields, defaultValue) => {
-  const result = { };
+  const result = {};
   for(const field of fields) result[field] = getField(obj, field, defaultValue);
   return result;
 }

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -1,7 +1,8 @@
 import {getField} from "./getField";
 
 /**
-  * Creates a new object whose fields are either equal to obj[field] or defaultValue.
+  * Creates a new object whose fields are either equal to obj[field]
+  * or defaultValue.
   * Useful for extracting a subset of fields from an object.
   *
   * @param obj the object to query the fields for.

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -4,7 +4,7 @@
   *
   * @param obj the object to query the fields for.
   * @param fields an array of the target fields, in string form. 
-  * @param defaultValue 
+  * @param defaultValue the value to be used if obj[field] === undefined.
  */
 const getFields = (obj, fields, defaultValue) => {
   const result = { };

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -8,7 +8,7 @@ import {getField} from "./getField";
   * @param fields an array of the target fields, in string form. 
   * @param defaultValue the value to be used if obj[field] === undefined.
  */
-const getFields = (obj, fields, defaultValue) => {
+export const getFields = (obj, fields, defaultValue) => {
   const result = { };
   for(const field of fields) result[field] = getField(obj, field, defaultValue);
   return result;

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -10,6 +10,6 @@ import {getField} from "./getField";
  */
 export const getFields = (obj, fields, defaultValue) => {
   const result = {};
-  for(const field of fields) result[field] = getField(obj, field, defaultValue);
+  for (const field of fields) result[field] = getField(obj, field, defaultValue);
   return result;
 }

--- a/src/main/webapp/components/utils/getFields.js
+++ b/src/main/webapp/components/utils/getFields.js
@@ -1,0 +1,5 @@
+const getFields = (obj, fields, defaultValue) => {
+  const result = { };
+  for(const field of fields) result[field] = getField(obj, field, defaultValue);
+  return result;
+}


### PR DESCRIPTION
This PR introduces two helper functions, used to fetch a single or a group of fields from an object. In both cases, the functions return a user specified **defaultValue** if the field is not available.

These functions sit within the _/utils_ folder, which will contain generic helper functions that may be used between components.