### PR TITLE
Fix master compilation failure

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
@@ -47,7 +47,7 @@ public class ParsedBuildbotData {
                             List<Log> logs, BuilderStatus status) {
     this.commitHash = commitHash;
     this.builderName = builderName;
-    this.logs = new LinkedList<>(logs);
+    this.logs = new ArrayList<>(logs);
     this.status = status;
   }
 

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
@@ -15,6 +15,7 @@
 package com.google.graphgeckos.dashboard.storage;
 
 import java.util.List;
+import java.util.ArrayList;
 
 /**
  * An immutable container used for providing stripped-down build bot information

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
@@ -14,6 +14,8 @@
 
 package com.google.graphgeckos.dashboard.storage;
 
+import java.util.List;
+
 /**
  * An immutable container used for providing stripped-down build bot information
  * to the GCDataRepository. Provides functionality for checking whether the information

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
@@ -14,8 +14,6 @@
 
 package com.google.graphgeckos.dashboard.storage;
 
-import java.util.List;
-
 /**
  * An immutable container used for providing stripped-down git information
  * to the GCDataRepository. Provides functionality for checking whether the information
@@ -78,7 +76,7 @@ public class ParsedGitData {
    *
    * @return the branch.
    */
-  List<String> getBranch() {
+  String getBranch() {
     return branch;
   }
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
@@ -14,6 +14,8 @@
 
 package com.google.graphgeckos.dashboard.storage;
 
+import java.util.List;
+
 /**
  * An immutable container used for providing stripped-down git information
  * to the GCDataRepository. Provides functionality for checking whether the information

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
@@ -14,6 +14,8 @@
 
 package com.google.graphgeckos.dashboard.storage;
 
+import com.google.cloud.Timestamp;
+
 /**
  * An immutable container used for providing stripped-down git information
  * to the GCDataRepository. Provides functionality for checking whether the information
@@ -27,17 +29,17 @@ package com.google.graphgeckos.dashboard.storage;
  */
 public class ParsedGitData {
   private final String commitHash;
-  private final String timestamp;
+  private final Timestamp timestamp;
   private final String branch;
 
   /**
    * Constructs an immutable instance of the ParsedGitData.
    *
    * @param commitHash the commit hash of the revision this data refers to
-   * @param timestamp the formatted time when the commit was pushed
+   * @param timestamp the time when the commit was pushed
    * @param branch branch of the LLVM project on which this commit was pushed
    */
-  public ParsedGitData(String commitHash, String timestamp, String branch) {
+  public ParsedGitData(String commitHash, Timestamp timestamp, String branch) {
     this.commitHash = commitHash;
     this.timestamp = timestamp;
     this.branch = branch;
@@ -67,7 +69,7 @@ public class ParsedGitData {
    *
    * @return the timestamp.
    */
-  String getTimestamp() {
+  Timestamp getTimestamp() {
     return timestamp;
   }
 


### PR DESCRIPTION
Branches #43 and #44 generated compilation failures since they had no imports for the classes they used (namely Lists). Added import java.util.List to both ParsedBuildbotData.java and ParsedGitData.java, and changed a LinkedList to an ArrayList, for performance reasons.