### PR TITLE
DatastoreRevisionEntity POJO | Spring-Datastore interface

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionData.java
@@ -16,6 +16,7 @@ package com.google.graphgeckos.dashboard.storage;
 
 import com.google.cloud.Timestamp;
 import java.util.List;
+import java.util.ArrayList;
 
 /**
  * An immutable container used for providing stripped-down git information
@@ -28,11 +29,22 @@ import java.util.List;
  * -timestamp: the formatted date when the commit was pushed
  * -branch: the branch of the LLVM project on which this commit was pushed
  */
+@Entity(name = "revision")
 class DatastoreRevisionData {
+  @Id
+  @Field(name = "commitHash")
   private String commitHash;
+  
+  @Field(name = "index")
   private int index;
+
+  @Field(name = "timestamp")
   private Timestamp timestamp;
+
+  @Field(name = "branch")
   private String branch;
+
+  @Field(name = "builders")
   private List<Builder> builders;
 
   DatastoreRevisionData(ParsedGitData creationData, int index) {

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionData.java
@@ -1,0 +1,69 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.graphgeckos.dashboard.storage;
+
+import com.google.cloud.Timestamp;
+import java.util.List;
+
+/**
+ * An immutable container used for providing stripped-down git information
+ * to the GCDataRepository. Provides functionality for checking whether the information
+ * is sufficient for creating an entry. Does not modify or validity check the individual
+ * contents of each field.
+ *
+ * Fields included: 
+ * -commitHash: the commit hash of the revision built by a certain build bot
+ * -timestamp: the formatted date when the commit was pushed
+ * -branch: the branch of the LLVM project on which this commit was pushed
+ */
+class DatastoreRevisionData {
+  private String commitHash;
+  private int index;
+  private Timestamp timestamp;
+  private String branch;
+  private List<Builder> builders;
+
+  DatastoreRevisionData(ParsedGitData creationData, int index) {
+    this.commitHash = creationData.getCommitHash();
+    this.index = index;
+    this.timestamp = creationData.getTimestamp();
+    this.branch = creationData.getBranch();
+    this.builders = new ArrayList<>();
+  }
+
+  String getCommitHash() {
+    return commitHash;
+  }
+
+  Timestamp getTimestamp() {
+    return timestamp;
+  }
+
+  String getBranch() {
+    return branch;
+  }
+
+  List<Builder> getBuilders() {
+    return builders;
+  }
+
+  void setIndex(int newIndex) {
+    index = newIndex;
+  }
+
+  void addBuilder(Builder newBuilder) {
+    builders.add(newBuilder);
+  }
+}

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionEntity.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionEntity.java
@@ -41,6 +41,7 @@ class DatastoreRevisionEntity {
   @Field(name = "branch")
   private String branch;
 
+  @Unindexed
   @Field(name = "builders")
   private List<Builder> builders;
 

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionEntity.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRevisionEntity.java
@@ -15,22 +15,19 @@
 package com.google.graphgeckos.dashboard.storage;
 
 import com.google.cloud.Timestamp;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
- * An immutable container used for providing stripped-down git information
- * to the GCDataRepository. Provides functionality for checking whether the information
- * is sufficient for creating an entry. Does not modify or validity check the individual
- * contents of each field.
- *
- * Fields included: 
- * -commitHash: the commit hash of the revision built by a certain build bot
- * -timestamp: the formatted date when the commit was pushed
- * -branch: the branch of the LLVM project on which this commit was pushed
+ * An intermediary container used by the Spring - Google Cloud Datastore integration,
+ * allowing easy creation/update of new entities in the database. It is created using
+ * a commit's metadata from git, and updated using
+ * {@link com.google.graphgeckos.dashboard.storage#Builder Builder} objects, which add
+ * compilation information from each buildbot. The scope of an instance is supposed to
+ * be contained inside a single method from DataRepository.
  */
 @Entity(name = "revision")
-class DatastoreRevisionData {
+class DatastoreRevisionEntity {
   @Id
   @Field(name = "commitHash")
   private String commitHash;
@@ -47,7 +44,11 @@ class DatastoreRevisionData {
   @Field(name = "builders")
   private List<Builder> builders;
 
-  DatastoreRevisionData(ParsedGitData creationData, int index) {
+  /**
+   * Constructs a DatastoreRevisionEntity from the raw commit information from git,
+   * and an index used for database ordering.
+   */
+  DatastoreRevisionEntity(ParsedGitData creationData, int index) {
     this.commitHash = creationData.getCommitHash();
     this.index = index;
     this.timestamp = creationData.getTimestamp();
@@ -55,26 +56,52 @@ class DatastoreRevisionData {
     this.builders = new ArrayList<>();
   }
 
+  /**
+   * Getter for the commitHash.
+   *
+   * @return the commitHash.
+   */
   String getCommitHash() {
     return commitHash;
   }
 
+  /**
+   * Getter for the timestamp.
+   *
+   * @return the timestamp.
+   */
   Timestamp getTimestamp() {
     return timestamp;
   }
 
+  /**
+   * Getter for the branch.
+   *
+   * @return the branch.
+   */
   String getBranch() {
     return branch;
   }
 
+  /**
+   * Getter for the builders.
+   *
+   * @return the builders.
+   */
   List<Builder> getBuilders() {
     return builders;
   }
 
+  /**
+   * Setter for the index. Used in the reindexing operation inside GCDataRepository.
+   */
   void setIndex(int newIndex) {
     index = newIndex;
   }
 
+  /**
+   * Adds a new builder to the builders list.
+   */
   void addBuilder(Builder newBuilder) {
     builders.add(newBuilder);
   }


### PR DESCRIPTION
DatastoreRevisionEntity is an intermediary container, used by the DataRepository implementation to simplify create and update operations.

Uses [Spring-Google Cloud Datastore integration](https://cloud.spring.io/spring-cloud-static/Greenwich.RC1/multi/multi__spring_data_cloud_datastore.html), creating a Datastore.Entity directly from a Java class. Each property of the class has been annotated according to the Spring documentation, so that it can properly create the Entity needed inside the database.

Will be used inside the createRevisionEntry method, only for creating an entry from a ParsedGitData object and inside the updateRevisionEntry, for easily acquiring, accessing and modifying the properties of an already existent entry.

closes #52 