### PR TITLE
Implement Structure for Header Component

### DIFF
--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -4,9 +4,14 @@ import * as React from "react";
  * Main Navigation Component
  */
 export const Header = () => {
+  const TITLE = "LLVM Build View";
+
   return (
     <header>
-    LLVM Build View
+      <Wrapper>
+        <span>{TITLE}</span>
+      </Wrapper>
+      <Navigation/>
     </header>
   );
 }

--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -10,7 +10,7 @@ export const Header = () => {
   return (
     <header>
       <Wrapper>
-        <span>{TITLE}</span>
+        <span className="title">{TITLE}</span>
       </Wrapper>
       <Navigation/>
     </header>

--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Navigation } from "./Navigation";
 
 /**
  * Main Navigation Component

--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -5,12 +5,12 @@ import { Navigation } from "./Navigation";
  * Main Navigation Component
  */
 export const Header = () => {
-  const TITLE = "LLVM Build View";
+  const TITLE = 'LLVM Build View';
 
   return (
-    <header className="header">
+    <header className='header'>
       <Wrapper>
-        <span className="title">{TITLE}</span>
+        <span className='title'>{TITLE}</span>
       </Wrapper>
       <Wrapper>
         <Navigation/>

--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -9,12 +9,12 @@ export const Header = () => {
 
   return (
     <header className='header'>
-      <Wrapper>
+      <div>
         <span className='title'>{TITLE}</span>
-      </Wrapper>
-      <Wrapper>
+      </div>
+      <div>
         <Navigation/>
-      </Wrapper>
+      </div>
     </header>
   );
 }

--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -8,11 +8,13 @@ export const Header = () => {
   const TITLE = "LLVM Build View";
 
   return (
-    <header>
+    <header className="header">
       <Wrapper>
         <span className="title">{TITLE}</span>
       </Wrapper>
-      <Navigation/>
+      <Wrapper>
+        <Navigation/>
+      </Wrapper>
     </header>
   );
 }


### PR DESCRIPTION
This PR implements the components needed to structure the Header Component.

The Header content is split into two wrappers: **one containing the title content** and **one containing the navigation component**.

The content is wrapped to support the styling that will be used to justify the Title and Navigation Components to the left and right hand side of the parent container respectively.

The image below illustrates the content of the two wrappers.

![image](https://user-images.githubusercontent.com/47117318/91439822-8fcae080-e865-11ea-9b26-ea33e3f131f2.png)

Closes #57 