### PR TITLE
BuildInfo POJOs Spring annotations

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
@@ -47,6 +47,7 @@ public class BuildInfo {
   private final Timestamp timestamp;
 
   @Field(name = "branch")
+  @Unindexed
   private final String branch;
 
   @Field(name = "builders")

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
@@ -95,4 +95,9 @@ public class BuildInfo {
     return builders;
   }
 
+  public boolean equals(BuildInfo other) {
+    return this.commitHash == other.commitHash && this.timestamp.equals(other.timestamp) &&
+           this.branch == other.branch && this.builders.equals(other.builders);
+  }
+
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
@@ -66,9 +66,7 @@ public class BuildInfo {
   }
 
   /**
-   * Getter for the Git commit hash of the associated revision.
-   *
-   * @return commitHash. Cannot be null.
+   * Getter for the Git commit hash of the associated revision. Cannot be null.
    */
   public String getCommitHash() {
     return commitHash;
@@ -76,27 +74,22 @@ public class BuildInfo {
 
   /**
    * Returns time of when the commit was pushed as a {@link com.google.cloud#Timestamp
-   * Timestamp} value.
-   *
-   * @return timestamp. Cannot be null.
+   * Timestamp} value. Cannot be null.
    */
   public Timestamp getTimestamp() {
     return timestamp;
   }
 
   /**
-   * Returns name of the Git branch where the revision was pushed.
-   *
-   * @return branch. Cannot be null.
+   * Returns name of the Git branch where the revision was pushed. Cannot be null.
    */
   public String getBranch() {
     return branch;
   }
 
   /**
-   * Returns builders which attempted the compilation of the revision.
-   *
-   * @return the list of builders. Cannot be null, neither it's elements.
+   * Returns builders which attempted the compilation of the revision. Cannot be null, and
+   * neither it's elements.
    */
   public List<Builder> getBuilders() {
     return builders;

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
@@ -54,9 +54,9 @@ public class BuildInfo {
   private final List<Builder> builders;
 
   /**
-   * Converts a ParsedGitData object to a BuildInfo object. This is used for adding
-   * entries to the Google Cloud Datastore, from the Git commit information received,
-   * and leaving the {@Code builders} field as empty, for later updates.
+   * Converts a {@link #ParsedGitData ParsedGitData} object to a BuildInfo object.
+   * This is used for adding entries to the Google Cloud Datastore, from the Git commit
+   * information received, and leaving the {@code builders} field as empty, for later updates.
    */
   BuildInfo(ParsedGitData creationData) {
     this.commitHash = creationData.getCommitHash();
@@ -68,16 +68,17 @@ public class BuildInfo {
   /**
    * Getter for the Git commit hash of the associated revision.
    *
-   * @return the commitHash. Cannot be null.
+   * @return commitHash. Cannot be null.
    */
   public String getCommitHash() {
     return commitHash;
   }
 
   /**
-   * Returns time of when the commit was pushed as a com.google.cloud.Timestamp value.
+   * Returns time of when the commit was pushed as a {@link com.google.cloud#Timestamp
+   * Timestamp} value.
    *
-   * @return the timestamp. Cannot be null.
+   * @return timestamp. Cannot be null.
    */
   public Timestamp getTimestamp() {
     return timestamp;
@@ -86,7 +87,7 @@ public class BuildInfo {
   /**
    * Returns name of the Git branch where the revision was pushed.
    *
-   * @return the branch. Cannot be null.
+   * @return branch. Cannot be null.
    */
   public String getBranch() {
     return branch;

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/BuildInfo.java
@@ -16,7 +16,6 @@ package com.google.graphgeckos.dashboard.storage;
 
 import com.google.cloud.Timestamp;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.Unindexed;


### PR DESCRIPTION
Added all needed Spring Cloud Datastore annotations for smooth GCD integration to BuildInfo and all related subclasses, and changed the timestamp field in said classes to google.cloud.Timestamp, for uniformity among all storage components.

Annotations added:
* @ Entity(name = \<kind\>) to BuildInfo and all subclasses.
* \@ Field and @ Id to BuildInfo fields.
* \@ Unindexed to builders field, since we don't need to query the database on that.
For more info:
https://cloud.spring.io/spring-cloud-static/Greenwich.RC1/multi/multi__spring_data_cloud_datastore.html

google.cloud.Timestamp:
Is the data format that can be read and transcribed into what Google Cloud Datastore uses internally. For more info: https://googleapis.dev/java/google-cloud-clients/0.92.0-alpha/com/google/cloud/datastore/TimestampValue.html

note: these files have already been reviewed in #36 . Only the Spring-specific annotations and the timestamp data type have been added on top of that.