### PR TITLE
DatastoreRepository Cleanup procedures

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -165,16 +165,6 @@ public class DatastoreRepository implements DataRepository {
     return storage.findById(commitHash, BuildInfo.class);
   }
 
-
-  /**
-   * Queries the database for a given entry, that has the Id set to the provided commitHash.
-   * Used to separate the usage from the actual Spring Datastore implementation.
-   * Returns null when nothing was found.
-   */
-  public BuildInfo getRevisionEntry(String commitHash) {
-    return storage.findById(commitHash, BuildInfo.class);
-  }
-
   /**
    * Queries all "revision" type entries, and deletes all which are older than a specified
    * amount of time. During this operation, this repository can be queried, but

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -15,6 +15,8 @@
 package com.google.graphgeckos.dashboard.storage;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -187,5 +189,115 @@ public class DatastoreRepositoryTests {
     AssertEquals(results.size(), 2);
     AssertEquals(results.get(0), dummy2);
     AssertEquals(results.get(1), dummy1);
+  }
+
+  /**
+   * Test deletion when entry is older than the timestamp.
+   */
+  @Test
+  public void testSingleEntityOlderCleanup() {
+    DatastoreRepository storage = new DatastoreRepository();
+
+    BuildInfo dummy = getDummyEntity("1");
+    storage.createRevisionEntry(dummy);
+    storage.deleteEntriesOlderThan(Timestamp.now());
+
+    Assert.assertNull(storage.getRevisionEntry("1"));
+  }
+
+  /**
+   * Test preservation when the entry is created at the same time as the timestamp.
+   */
+  @Test
+  public void testSingleEntitySameAgeCleanup() {
+    DatastoreRepository storage = new DatastoreRepository();
+
+    dummy = getDummyEntity("1");
+    storage.createRevisionEntry(dummy);
+    Timestamp savedTime = dummy.getTimestamp();
+    storage.deleteEntriesOlderThan(savedTime);
+
+    Assert.assertNotNull(storage.getRevisionEntry("1"));
+  }
+
+  /**
+   * Test preservation when the entry is newer than the timestamp.
+   */
+  @Test
+  public void testSingleEntityNewerCleanup() {
+    DatastoreRepository storage = new DatastoreRepository();
+
+    dummy = getDummyEntity("1");
+    storage.createRevisionEntry(dummy);
+    storage.deleteEntriesOlderThan(savedTime);
+
+    Assert.assertNotNull(storage.getRevisionEntry("1"));
+  }
+
+  /**
+   * Test multiple deletions for all entries older than the timestamp.
+   */
+  @Test
+  public void testMultipleEntityCleanupAllDeleted() {
+    DatastoreRepository storage = new DatastoreRepository();
+
+    BuildInfo dummy1 = getDummyEntity("1");
+    BuildInfo dummy2 = getDummyEntity("2");
+    BuildInfo dummy3 = getDummyEntity("3");
+
+    storage.createRevisionEntry(dummy1);
+    storage.createRevisionEntry(dummy2);
+    storage.createRevisionEntry(dummy3);
+
+    storage.deleteEntriesOlderThan(Timestamp.now());
+
+    Assert.assertNull(storage.getRevisionEntry("1"));
+    Assert.assertNull(storage.getRevisionEntry("2"));
+    Assert.assertNull(storage.getRevisionEntry("3"));
+  }
+
+  /**
+   * Test partial deletion of entries.
+   */
+  @Test
+  public void testMultipleEntityCleanupPartialDeleted() {
+    DatastoreRepository storage = new DatastoreRepository();
+
+    BuildInfo dummy1 = getDummyEntity("1");
+    BuildInfo dummy2 = getDummyEntity("2");
+    BuildInfo dummy3 = getDummyEntity("3");
+
+    storage.createRevisionEntry(dummy1);
+    storage.createRevisionEntry(dummy2);
+    storage.createRevisionEntry(dummy3);
+    Timestamp savedTime = dummy3.getTimestamp();
+
+    storage.deleteEntriesOlderThan(savedTime);
+
+    Assert.assertNull(storage.getRevisionEntry("1"));
+    Assert.assertNull(storage.getRevisionEntry("2"));
+    Assert.assertNotNull(storage.getRevisionEntry("3"));
+  }
+
+  /**
+   * Test no deletion of entries.
+   */
+  @Test
+  public void testMultipleEntityCleanupNoDeletion() {
+    DatastoreRepository storage = new DatastoreRepository();
+
+    BuildInfo dummy1 = getDummyEntity("1");
+    BuildInfo dummy2 = getDummyEntity("2");
+    BuildInfo dummy3 = getDummyEntity("3");
+
+    storage.createRevisionEntry(dummy1);
+    storage.createRevisionEntry(dummy2);
+    storage.createRevisionEntry(dummy3);
+
+    storage.deleteEntriesOlderThan(savedtime);
+
+    Assert.assertNotNull(storage.getRevisionEntry("1"));
+    Assert.assertNotNull(storage.getRevisionEntry("2"));
+    Assert.assertNotNull(storage.getRevisionEntry("3"));
   }
 }


### PR DESCRIPTION
This PR adds the cleanup procedure, parameters class and scheduling to GCDataRepository from #66 . 

The cleanup procedure is a Runnable() implementation, which queries the datastore for all entries older than a date provided by the CleanupParameters class, then deletes those entries.
The CleanupParameters class is a subclass of the GCDataRepository, which contains all the parameters needed for the cleanup procedure (e.g. Entry TTL, cleanup frequency, etc.).
The scheduling is done via the [ScheduledExecutorService](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ScheduledExecutorService.html#:~:text=Interface%20ScheduledExecutorService&text=An%20ExecutorService%20that%20can%20schedule,to%20cancel%20or%20check%20execution.) provided by Java.