### PR TITLE
Change DataRepository specsheet

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
@@ -24,7 +24,7 @@ public interface DataRepository {
    * If there already is an entry with the same commit hash, ignores the request.
    *
    * @param entryData a ParsedGitData instance, must have a non-null "commitHash" field
-   * @return true if operation completed successfully.
+   * @return true only if the operation completed successfully.
    * @throws IllegalArgumentException if entryData is null
    */
   boolean createRevisionEntry(ParsedGitData entryData) throws IllegalArgumentException;
@@ -35,7 +35,7 @@ public interface DataRepository {
    * ignores the request.
    *
    * @param updateData a ParsedBuildbotData instance, must have a non-null "commitHash" field
-   * @return true if operation completed successfully.
+   * @return true only if the operation completed successfully.
    * @throws IllegalArgumentException if updateData is null.
    */
   boolean updateRevisionEntry(ParsedBuildbotData updateData) throws IllegalArgumentException;
@@ -46,7 +46,7 @@ public interface DataRepository {
    *
    * @param commitHash the String representation of the commit hash of the revision data to
    * be deleted
-   * @return true if operation completed successfully.
+   * @return true only if the operation completed successfully.
    * @throws IllegalArgumentException if commitHash is null
    */
   boolean deleteRevisionEntry(String commitHash) throws IllegalArgumentException;

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
@@ -27,7 +27,7 @@ public interface DataRepository {
    * @return true if operation completed successfully.
    * @throws IllegalArgumentException if entryData is null
    */
-  void createRevisionEntry(ParsedGitData entryData) throws IllegalArgumentException;
+  boolean createRevisionEntry(ParsedGitData entryData) throws IllegalArgumentException;
 
   /**
    * Updates an existing revision's database entry, with the individual information from
@@ -38,7 +38,7 @@ public interface DataRepository {
    * @return true if operation completed successfully.
    * @throws IllegalArgumentException if updateData is null.
    */
-  void updateRevisionEntry(ParsedBuildbotData updateData) throws IllegalArgumentException;
+  boolean updateRevisionEntry(ParsedBuildbotData updateData) throws IllegalArgumentException;
 
   /**
    * Deletes a revision's database entry, based on it's commit hash. Has no effect if there
@@ -49,7 +49,7 @@ public interface DataRepository {
    * @return true if operation completed successfully.
    * @throws IllegalArgumentException if commitHash is null
    */
-  void deleteRevisionEntry(String commitHash) throws IllegalArgumentException;
+  boolean deleteRevisionEntry(String commitHash) throws IllegalArgumentException;
 
   /**
    * Queries the database for a specified amount of entries of type "revision", going down
@@ -76,5 +76,5 @@ public interface DataRepository {
    *     associated to that commitHash.
    * @throws IllegalArgumentException if commitHash is null
    */
-  public BuildInfo getRevisionEntry(String commitHash) throws IllegalArgumentException;
+  BuildInfo getRevisionEntry(String commitHash) throws IllegalArgumentException;
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
@@ -63,8 +63,7 @@ public interface DataRepository {
    *     {@code offset} and {@code number}, returns all the available entries from that range.
    * @throws IllegalArgumentException if either number or offset are < 0
    */
-  List<BuildInfo> getLastRevisionEntries(int number, int offset)
-                                                          throws IllegalArgumentException;
+  List<BuildInfo> getLastRevisionEntries(int number, int offset) throws IllegalArgumentException;
 
   /**
    * Queries the database for a given entry, that has the primary key set

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
@@ -24,9 +24,8 @@ public interface DataRepository {
    * If there already is an entry with the same commit hash, ignores the request.
    *
    * @param entryData a ParsedGitData instance, must have a non-null "commitHash" field
-   * @throws IllegalArgumentException if entryData is null, or {@link 
-   *       com.google.graphgeckos.dashboard.storage.ParsedGitData#validCreateData()
-   *       entryData.validCreateData()} returns false
+   * @return true if operation completed successfully.
+   * @throws IllegalArgumentException if entryData is null
    */
   void createRevisionEntry(ParsedGitData entryData) throws IllegalArgumentException;
 
@@ -36,9 +35,8 @@ public interface DataRepository {
    * ignores the request.
    *
    * @param updateData a ParsedBuildbotData instance, must have a non-null "commitHash" field
-   * @throws IllegalArgumentException if updateData or {@link
-   *       com.google.graphgeckos.dashboard.storage.ParsedBuildbotData#validUpdateData()
-   *       updateData.validUpdateData()} returns false
+   * @return true if operation completed successfully.
+   * @throws IllegalArgumentException if updateData is null.
    */
   void updateRevisionEntry(ParsedBuildbotData updateData) throws IllegalArgumentException;
 
@@ -48,6 +46,7 @@ public interface DataRepository {
    *
    * @param commitHash the String representation of the commit hash of the revision data to
    * be deleted
+   * @return true if operation completed successfully.
    * @throws IllegalArgumentException if commitHash is null
    */
   void deleteRevisionEntry(String commitHash) throws IllegalArgumentException;
@@ -67,4 +66,15 @@ public interface DataRepository {
    */
   Iterable<BuildInfo> getLastRevisionEntries(int number, int offset)
                                                           throws IllegalArgumentException;
+
+  /**
+   * Queries the database for a given entry, that has the primary key set
+   * to the provided commitHash.
+   *
+   * @param commitHash the commitHash to search for
+   * @return null if no object was found, else a BuildInfo instance of the database entry
+   *     associated to that commitHash.
+   * @throws IllegalArgumentException if commitHash is null
+   */
+  public BuildInfo getRevisionEntry(String commitHash) throws IllegalArgumentException;
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DataRepository.java
@@ -58,13 +58,12 @@ public interface DataRepository {
    * @param number the number of database entries to retrieve
    * @param offset the offset from the latest database entry, for which to consider
    *     the requested number of entries
-   * @return an iterable object containing at most {@code number} entries starting
-   *     from the latest entry - {@code offset}. If the database has not enough entries
-   *     for the requested {@code offset} and {@code number}, returns all the available
-   *     entries from that range.
+   * @return a list containing at most {@code number} entries starting from the latest
+   *     entry - {@code offset}. If the database has not enough entries for the requested
+   *     {@code offset} and {@code number}, returns all the available entries from that range.
    * @throws IllegalArgumentException if either number or offset are < 0
    */
-  Iterable<BuildInfo> getLastRevisionEntries(int number, int offset)
+  List<BuildInfo> getLastRevisionEntries(int number, int offset)
                                                           throws IllegalArgumentException;
 
   /**


### PR DESCRIPTION
With this PR, the behaviour of DataRepository is changed and extended in the following ways:

* createRevisionEntry, updateRevisionEntry, deleteRevisionEntry now return a boolean value, depending on the success of the operation
* added getRevisionEntry method, to query specifically after a commitHash. This method existed in the DatastoreRepository implementation, but was moved to be public, since it will be needed in later stages of the project (e.g. analyzing a specific revision)
* ParsedGitData and ParsedBuildbotData are now expected to be pre-sanitized, and should not exist with invalid data, as such, their field checks will no longer be called