### PR TITLE
Added fail-fast null-checking in ParsedBuildbotData and ParsedGitData

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
@@ -58,16 +58,6 @@ public class ParsedBuildbotData {
   }
 
   /**
-   * Checks for the existance of the fields necessary for updating a database entry.
-   * Does not check the validity of each field.
-   *
-   * @return true if all required fields are available, false if not.
-   */
-  boolean validUpdateData() {
-    return (commitHash != null && builderName != null && logs != null && status != null);
-  }
-
-  /**
    * Converts this instance to an instance of
    * {@link com.gogle.graphgeckos.dashboard.storage.Builder Builder}.
    *

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
@@ -43,9 +43,14 @@ public class ParsedBuildbotData {
    * @param logs logs for each individual stage of compilation. See {@link
    *      #com.google.graphgeckos.dashboard.storage.Log Log}
    * @param status the results of the compilation (true for passed, false for failed)
+   * @throws IllegalArgumentException if either parameter is null
    */
   public ParsedBuildbotData(String commitHash, String builderName,
-                            List<Log> logs, BuilderStatus status) {
+                            List<Log> logs, BuilderStatus status) throws IllegalArgumentException {
+    if (commitHash != null && builderName != null && logs != null && status != null) {
+      throw new IllegalArgumentException("no field in ParsedBuildbotData can be null");
+    }
+
     this.commitHash = commitHash;
     this.builderName = builderName;
     this.logs = new ArrayList<>(logs);

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedBuildbotData.java
@@ -47,7 +47,7 @@ public class ParsedBuildbotData {
    */
   public ParsedBuildbotData(String commitHash, String builderName,
                             List<Log> logs, BuilderStatus status) throws IllegalArgumentException {
-    if (commitHash != null && builderName != null && logs != null && status != null) {
+    if (commitHash == null || builderName == null || logs == null || status == null) {
       throw new IllegalArgumentException("no field in ParsedBuildbotData can be null");
     }
 

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/ParsedGitData.java
@@ -38,21 +38,17 @@ public class ParsedGitData {
    * @param commitHash the commit hash of the revision this data refers to
    * @param timestamp the time when the commit was pushed
    * @param branch branch of the LLVM project on which this commit was pushed
+   * @throws IllegalArgumentException if commitHash is null
    */
-  public ParsedGitData(String commitHash, Timestamp timestamp, String branch) {
+  public ParsedGitData(String commitHash, Timestamp timestamp, String branch)
+                                                                throws IllegalArgumentException {
+    if (commitHash == null) {
+      throw new IllegalArgumentException("ParsedGitData's commitHash cannot be null");
+    }
+
     this.commitHash = commitHash;
     this.timestamp = timestamp;
     this.branch = branch;
-  }
-
-  /**
-   * Checks for the existance of the fields necessary for creating a database entry.
-   * Does not check the validity of each field.
-   *
-   * @return true if all required fields are available, false if not.
-   */
-  boolean validCreateData() {
-    return commitHash != null;
   }
 
   /**


### PR DESCRIPTION
Removed the self-checking methods in ParsedBuildbotData and ParsedGitData, and instead moved the checks inside their constructors. This guarantees that no instance of them can have invalid fields, and thus requires less checks further down the application.

Now, their constructors throw IllegalArgumentException when a required field is null.