### PR TITLE
Deprecate Wrapper Component

### DIFF
--- a/src/main/webapp/App.js
+++ b/src/main/webapp/App.js
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {BuildSnapshotContainer} from "./components/BuildSnapshotContainer";
 import {Header} from "./components/Header";
-import {Wrapper} from "./components/Wrapper";
 
 /**
  * Main App that is Rendered to the Page.
@@ -10,9 +9,9 @@ import {Wrapper} from "./components/Wrapper";
  */
 export const App = (props) => {
   return (
-    <Wrapper>
+    <div>
       <Header/>
       <BuildSnapshotContainer/>
-    </Wrapper>
+    </div>
   );
 }

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {BuildSnapshot} from "./BuildSnapshot";
-import {Wrapper} from "./Wrapper";
 
 /**
  * Container Component for BuildSnapshots.
@@ -11,8 +10,8 @@ import {Wrapper} from "./Wrapper";
 export const BuildSnapshotContainer = (props) => {
   const data = props.data;
   return (
-    <Wrapper>
+    <div>
       {data.map(snapshotData => <BuildSnapshot data={snapshotData}/>)}
-    </Wrapper>
+    </div>
   );
 }


### PR DESCRIPTION
This PR removes all uses of the Wrapper component, based on feedback received on #48 regarding the in-utility of the generic Wrapper Component.
An in-depth explanation detailing the motivation for deprecating this component is available on the [initial pull request](https://github.com/googleinterns/step240-2020/pull/48?w=1).

The [closing comment](https://github.com/googleinterns/step240-2020/pull/48?w=1#issuecomment-681932942) provides explicit detail of the complications introduced with the Wrapper Component.