### PR TITLE
Add missing return statement to Navigation Item Component

### DIFF
--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -8,7 +8,11 @@ import * as React from 'react';
  * @param {string} props.innerText rendered text content of node.
  */
 const NavigationItem = (props) => {
-  <li><a href = {props.href}>{props.innerText}</a></li>
+  return (
+    <li>
+      <a href = {props.href}>{props.innerText}</a>
+    </li>
+  )
 }
 
 /**

--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -12,7 +12,7 @@ const NavigationItem = (props) => {
     <li>
       <a href = {props.href}>{props.innerText}</a>
     </li>
-  )
+  );
 }
 
 /**


### PR DESCRIPTION
This PR adds a return statement missing from the Navigation Item Component, causing the front-end to fail.