### PR TITLE
Replace App Wrapper with React Fragment

### DIFF
--- a/src/main/webapp/App.js
+++ b/src/main/webapp/App.js
@@ -9,9 +9,9 @@ import {Header} from "./components/Header";
  */
 export const App = (props) => {
   return (
-    <div>
+    <React.Fragment>
       <Header/>
       <BuildSnapshotContainer/>
-    </div>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION
This PR implements a change that replaces the < div > around the top level app component, and instead replaces it with a [Fragment](https://reactjs.org/docs/fragments.html).

With the < div >, the app structure would be:

< body>
 < div class="App" >
  app content here
 < /div >
< /body >

With < React.Fragment> it loses the wrapping div:

< body >
app content here
< /body >