### PR TITLE
Remove Redundant Param in App Component

### DIFF
--- a/src/main/webapp/App.js
+++ b/src/main/webapp/App.js
@@ -3,11 +3,9 @@ import {BuildSnapshotContainer} from "./components/BuildSnapshotContainer";
 import {Header} from "./components/Header";
 
 /**
- * Main App that is Rendered to the Page.
- * 
- * @param {*} props arbituary input properties for our application to use.
+ * Main App reponsible for rendering content to the page.
  */
-export const App = (props) => {
+export const App = _ => {
   return (
     <div>
       <Header/>


### PR DESCRIPTION
This PR removes the props parameter from the App component since it currently expects no arguments.

An underscore (_) was used as a placeholder to indicate nothing is expected.