### PR TITLE
Update BuildBotData to work with DatastoreTemplate

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -77,43 +77,46 @@ public class BuildBotData {
   }
 
   /**
-   * Returns the name of the builder bot. Cannot be null.
+   * @return the name of the builder. Cannot be null.
    */
+  @NonNull
   public String getName() {
     return name;
   }
 
   /**
-   * Returns the list of logs for each compilation stage. Cannot be null.
+   * @return the list of logs for each compilation stage. Cannot be null.
    */
+  @NonNull
   public List<Log> getLogs() {
     return logs;
   }
 
   /**
-   * Returns the compilation status of the builder. Cannot be null.
+   * @return the compilation status of the builder. Cannot be null.
    */
+  @NonNull
   public BuilderStatus getStatus() {
     return status;
   }
 
   /**
-   * Returns the commit hash of the commit tested by the current buildbot.
+   * @return the commit hash of the commit tested by the current buildbot. Cannot be null.
    */
+  @NonNull
   public String getCommitHash() {
     return commitHash;
   }
 
   /**
-   * Returns the timestamp of the build.
+   * @return the timestamp of the build.
    */
+  @NonNull
   public Timestamp getTimestamp() {
     return timestamp;
   }
 
   /**
-   * Sets the name of the builder bot.
-   *
    * @param name the new value for the {@code name} field. Should not be null.
    */
   public void setName(@NonNull String name) {
@@ -121,8 +124,6 @@ public class BuildBotData {
   }
 
   /**
-   * Sets the list of logs for each compilation stage.
-   *
    * @param logs the new value for the {@code logs} field. Should not be null.
    */
   public void setLogs(@NonNull List<Log> logs) {
@@ -130,8 +131,6 @@ public class BuildBotData {
   }
 
   /**
-   * Sets the compilation status of the builder.
-   *
    * @param status the new value for the {@code status} field. Should not be null.
    */
   public void setStatus(@NonNull BuilderStatus status) {
@@ -139,8 +138,6 @@ public class BuildBotData {
   }
 
   /**
-   * Sets the commit hash of the commit tested by the current buildbot.
-   *
    * @param commitHash the new value for the {@code commitHash} field. Should not be null.
    */
   public void setCommitHash(@NonNull String commitHash) {
@@ -148,8 +145,6 @@ public class BuildBotData {
   }
 
   /**
-   * Sets the timestamp of the build.
-   *
    * @param timestamp the new value for the {@code timestamp} field. Should not be null.
    */
   public void setTimestamp(@NonNull Timestamp timestamp) {

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -76,77 +76,47 @@ public class BuildBotData {
     this.status = status;
   }
 
-  /**
-   * @return the name of the builder. Cannot be null.
-   */
   @NonNull
   public String getName() {
     return name;
   }
 
-  /**
-   * @return the list of logs for each compilation stage. Cannot be null.
-   */
   @NonNull
   public List<Log> getLogs() {
     return logs;
   }
 
-  /**
-   * @return the compilation status of the builder. Cannot be null.
-   */
   @NonNull
   public BuilderStatus getStatus() {
     return status;
   }
 
-  /**
-   * @return the commit hash of the commit tested by the current buildbot. Cannot be null.
-   */
   @NonNull
   public String getCommitHash() {
     return commitHash;
   }
 
-  /**
-   * @return the timestamp of the build.
-   */
   @NonNull
   public Timestamp getTimestamp() {
     return timestamp;
   }
 
-  /**
-   * @param name the new value for the {@code name} field. Should not be null.
-   */
   public void setName(@NonNull String name) {
     this.name = name;
   }
 
-  /**
-   * @param logs the new value for the {@code logs} field. Should not be null.
-   */
   public void setLogs(@NonNull List<Log> logs) {
     this.logs = new ArrayList<>(logs);
   }
 
-  /**
-   * @param status the new value for the {@code status} field. Should not be null.
-   */
   public void setStatus(@NonNull BuilderStatus status) {
     this.status = status;
   }
 
-  /**
-   * @param commitHash the new value for the {@code commitHash} field. Should not be null.
-   */
   public void setCommitHash(@NonNull String commitHash) {
     this.commitHash = commitHash;
   }
 
-  /**
-   * @param timestamp the new value for the {@code timestamp} field. Should not be null.
-   */
   public void setTimestamp(@NonNull Timestamp timestamp) {
     this.timestamp = timestamp;
   }

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -112,35 +112,45 @@ public class BuildBotData {
   }
 
   /**
-   * Sets the name of the builder bot. Should not be null.
+   * Sets the name of the builder bot.
+   *
+   * @param name the new value for the {@code name} field. Should not be null.
    */
   public void setName(@NonNull String name) {
     this.name = name;
   }
 
   /**
-   * Sets the list of logs for each compilation stage. Should not be null.
+   * Sets the list of logs for each compilation stage.
+   *
+   * @param logs the new value for the {@code logs} field. Should not be null.
    */
   public void setLogs(@NonNull List<Log> logs) {
     this.logs = new ArrayList<>(logs);
   }
 
   /**
-   * Sets the compilation status of the builder. Should not be null.
+   * Sets the compilation status of the builder.
+   *
+   * @param status the new value for the {@code status} field. Should not be null.
    */
   public void setStatus(@NonNull BuilderStatus status) {
     this.status = status;
   }
 
   /**
-   * Sets the commit hash of the commit tested by the current buildbot. Should not be null.
+   * Sets the commit hash of the commit tested by the current buildbot.
+   *
+   * @param commitHash the new value for the {@code commitHash} field. Should not be null.
    */
   public void setCommitHash(@NonNull String commitHash) {
     this.commitHash = commitHash;
   }
 
   /**
-   * Sets the timestamp of the build. Should not be null.
+   * Sets the timestamp of the build.
+   *
+   * @param timestamp the new value for the {@code timestamp} field. Should not be null.
    */
   public void setTimestamp(@NonNull Timestamp timestamp) {
     this.timestamp = timestamp;

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -18,6 +18,8 @@ import com.google.cloud.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
+import org.springframework.cloud.gcp.data.datastore.core.mapping.Field;
+import org.springframework.data.annotation.Transient;
 
 /**
  * Contains the information retrieved from a single build bot. It is used as a member
@@ -33,23 +35,44 @@ public class BuildBotData {
    * it in the right {@link BuildInfo} in the storage.
    * Used in {@link com.google.graphgeckos.dashboard.storage.DatastoreRepository}.
    */
+  @Transient
+  @Field(name = "commitHash")
   private String commitHash;
 
-  /* The timestamp of the build. */
+  /** 
+   * The timestamp of the build. 
+   */
+  @Field(name = "timestamp")
   private Timestamp timestamp;
 
-  /* Name of the buildbot. */
+  /**
+   * Name of the buildbot.
+   */
+  @Field(name = "name")
   private String name;
 
   /**
    * The logs of each compilation stage, stored as described by {@link Log}.
    */
+  @Field(name = "logs")
   private final List<Log> logs = new ArrayList<>();
 
   /**
    * Builder compilation status, as described by {@link BuilderStatus}.
    */
+  @Field(name = "status")
   private BuilderStatus status;
+
+  /**
+   * Sets all fields to null. Only to be used by Spring GCP.
+   */
+  public BuildBotData() {
+    this.commitHash = null;
+    this.timestamp = null;
+    this.name = null;
+    this.logs = null;
+    this.status = null;
+  }
 
   public BuildBotData(String commitHash, String name, List<Log> logs, BuilderStatus status) {
     this.commitHash = commitHash;
@@ -57,8 +80,6 @@ public class BuildBotData {
     this.logs.addAll(logs);
     this.status = status;
   }
-
-  public BuildBotData() {}
 
   /**
    * Returns the name of the builder bot. Cannot be null.
@@ -93,6 +114,41 @@ public class BuildBotData {
    */
   public Timestamp getTimestamp() {
     return timestamp;
+  }
+
+    /**
+   * Returns the name of the builder bot. Cannot be null.
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Returns the list of logs for each compilation stage. Cannot be null.
+   */
+  public void getLogs(List<Log> logs) {
+    this.logs = new ArrayList<>(logs);
+  }
+
+  /**
+   * Returns the compilation status of the builder. Cannot be null.
+   */
+  public void getStatus(BuilderStatus status) {
+    this.status = status;
+  }
+
+  /**
+   * Returns the commit hash of the commit tested by the current buildbot.
+   */
+  public void getCommitHash(String commitHash) {
+    this.commitHash = commitHash;
+  }
+
+  /**
+   * Returns the timestamp of the build.
+   */
+  public void getTimestamp(Timestamp timestamp) {
+    this.timestamp = timestamp;
   }
 
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.Field;
 import org.springframework.data.annotation.Transient;
+import org.springframework.lang.NonNull;
 
 /**
  * Contains the information retrieved from a single build bot. It is used as a member
@@ -64,15 +65,9 @@ public class BuildBotData {
   private BuilderStatus status;
 
   /**
-   * Sets all fields to null. Only to be used by Spring GCP.
+   * Only used by Spring GCP.
    */
-  public BuildBotData() {
-    this.commitHash = null;
-    this.timestamp = null;
-    this.name = null;
-    this.logs = null;
-    this.status = null;
-  }
+  public BuildBotData() { }
 
   public BuildBotData(String commitHash, String name, List<Log> logs, BuilderStatus status) {
     this.commitHash = commitHash;
@@ -117,37 +112,37 @@ public class BuildBotData {
   }
 
     /**
-   * Returns the name of the builder bot. Cannot be null.
+   * Sets the name of the builder bot. May not be null.
    */
-  public void setName(String name) {
+  public void setName(@NonNull String name) {
     this.name = name;
   }
 
   /**
-   * Returns the list of logs for each compilation stage. Cannot be null.
+   * Sets the list of logs for each compilation stage. May not be null.
    */
-  public void getLogs(List<Log> logs) {
+  public void setLogs(@NonNull List<Log> logs) {
     this.logs = new ArrayList<>(logs);
   }
 
   /**
-   * Returns the compilation status of the builder. Cannot be null.
+   * Sets the compilation status of the builder. May not be null.
    */
-  public void getStatus(BuilderStatus status) {
+  public void setStatus(@NonNull BuilderStatus status) {
     this.status = status;
   }
 
   /**
-   * Returns the commit hash of the commit tested by the current buildbot.
+   * Sets the commit hash of the commit tested by the current buildbot. May not be null.
    */
-  public void getCommitHash(String commitHash) {
+  public void setCommitHash(@NonNull String commitHash) {
     this.commitHash = commitHash;
   }
 
   /**
-   * Returns the timestamp of the build.
+   * Sets the timestamp of the build. May not be null.
    */
-  public void getTimestamp(Timestamp timestamp) {
+  public void setTimestamp(@NonNull Timestamp timestamp) {
     this.timestamp = timestamp;
   }
 

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -67,7 +67,7 @@ public class BuildBotData {
   /**
    * Only used by Spring GCP.
    */
-  public BuildBotData() { }
+  public BuildBotData() {}
 
   public BuildBotData(String commitHash, String name, List<Log> logs, BuilderStatus status) {
     this.commitHash = commitHash;

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -111,36 +111,36 @@ public class BuildBotData {
     return timestamp;
   }
 
-    /**
-   * Sets the name of the builder bot. May not be null.
+  /**
+   * Sets the name of the builder bot. Should not be null.
    */
   public void setName(@NonNull String name) {
     this.name = name;
   }
 
   /**
-   * Sets the list of logs for each compilation stage. May not be null.
+   * Sets the list of logs for each compilation stage. Should not be null.
    */
   public void setLogs(@NonNull List<Log> logs) {
     this.logs = new ArrayList<>(logs);
   }
 
   /**
-   * Sets the compilation status of the builder. May not be null.
+   * Sets the compilation status of the builder. Should not be null.
    */
   public void setStatus(@NonNull BuilderStatus status) {
     this.status = status;
   }
 
   /**
-   * Sets the commit hash of the commit tested by the current buildbot. May not be null.
+   * Sets the commit hash of the commit tested by the current buildbot. Should not be null.
    */
   public void setCommitHash(@NonNull String commitHash) {
     this.commitHash = commitHash;
   }
 
   /**
-   * Sets the timestamp of the build. May not be null.
+   * Sets the timestamp of the build. Should not be null.
    */
   public void setTimestamp(@NonNull Timestamp timestamp) {
     this.timestamp = timestamp;


### PR DESCRIPTION
DatastoreTemplate requires it's entities to have a default constructor, properties have a field name, and setters for all fields. This PR adds all those elements for BuildBotData.