### PR TITLE
Simplify BuilderStatus

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderStatus.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderStatus.java
@@ -14,28 +14,11 @@
 
 package com.google.graphgeckos.dashboard.datatypes;
 
-import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
-
 /**
  * Represents buildbot statuses.
  */
-@Entity(name = "buildStatus")
 public enum BuilderStatus {
-  FAILED("failed"),
-  PASSED("passed"),
-  LOST("lost");
-
-  private final String status;
-
-  BuilderStatus(String status) {
-    this.status = status;
-  }
-
-  /**
-   * Returns the String representation of the status. Cannot be null.
-   */
-  public String getStatus() {
-    return status;
-  }
-
+  FAILED,
+  PASSED,
+  LOST;
 }


### PR DESCRIPTION
Spring GCP wasn't playing nice with this enum, and by removing all the unnecessary complexity, it works as intended. By default, DatastoreTemplate converts enums to Strings, as a result the status property was redundant.