### PR TITLE
Change BuildInfo equals method

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
@@ -114,7 +114,7 @@ public class BuildInfo {
     }
     BuildInfo other = (BuildInfo) o;
     return commitHash.equals(other.commitHash) && timestamp.equals(other.timestamp) &&
-      branch.equals(other.branch) && builders.equals(other.builders);
+           branch.equals(other.branch) && builders.equals(other.builders);
   }
 
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
@@ -101,9 +101,20 @@ public class BuildInfo {
     builders.add(update);
   }
 
-  public boolean equals(BuildInfo other) {
-    return this.commitHash == other.commitHash && this.timestamp.equals(other.timestamp) &&
-           this.branch == other.branch && this.builders.equals(other.builders);
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null) {
+      return false;
+    }
+    if (!(o instanceof BuildInfo)) {
+      return false;
+    }
+    BuildInfo other = (BuildInfo) o;
+    return commitHash.equals(other.commitHash) && timestamp.equals(other.timestamp) &&
+      branch.equals(other.branch) && builders.equals(other.builders);
   }
 
 }


### PR DESCRIPTION
In Java ```equals``` method is an [Object class method](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html) that should be annotated with ```@Override```annotation and have and instance of Object class as and argument. Since all Java classes automatically extends Object class this method should be implemented in a described way in all classes where it is implemented. 