### PR TITLE
Create BuilderIndex class to store inside Datastore

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderIndex.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderIndex.java
@@ -16,6 +16,7 @@ package com.google.graphgeckos.dashboard.datatypes;
 
 import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.Field;
+import org.springframework.cloud.gcp.data.datastore.core.mapping.Unindexed;
 import org.springframework.data.annotation.Id;
 
 /**
@@ -30,6 +31,7 @@ public class BuilderIndex {
   @Field(name = "builderName")
   private String name;
 
+  @Unindexed
   @Field(name = "timestamp")
   private int index;
 

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderIndex.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderIndex.java
@@ -1,0 +1,90 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.graphgeckos.dashboard.datatypes;
+
+import org.springframework.cloud.gcp.data.datastore.core.mapping.Entity;
+import org.springframework.cloud.gcp.data.datastore.core.mapping.Field;
+import org.springframework.data.annotation.Id;
+
+/**
+ * This class encapsulates the information needed to retain the last revision index
+ * of a builder. Since builders do not compile all revisions sequentially, they maintain
+ * an internal index of compiled revisions, which differs on a builder by builder basis.
+ * Used as a Datastore entity inside DatastoreRepository.
+ */
+@Entity(name = "index")
+public class BuilderIndex {
+  @Id
+  @Field(name = "builderName")
+  private String name;
+
+  @Field(name = "timestamp")
+  private int index;
+
+  /**
+   * Used only by Spring GCP.
+   */
+  public BuilderIndex() { }
+
+  /**
+   * Constructs the BuilderIndex instance to be stored inside GCD.
+   */
+  public BuilderIndex(String name, int index) {
+    this.name = name;
+    this.index = index;
+  }
+
+  /**
+   * @return the name of the builder.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the index of the builder.
+   */
+  public int getIndex() {
+    return index;
+  }
+
+  /**
+   * @param name the new name of the builder
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * @param index the new index of the builder
+   */
+  public void setIndex(int index) {
+    this.index = index;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || !(o instanceof BuilderIndex)) {
+      return false;
+    }
+    
+    if (o == this) {
+      return true;
+    }
+
+    BuildInfo other = (BuilderIndex) o;
+    return this.name == other.name && this.index == other.index;
+  }
+}

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderIndex.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderIndex.java
@@ -35,43 +35,25 @@ public class BuilderIndex {
   @Field(name = "timestamp")
   private int index;
 
-  /**
-   * Used only by Spring GCP.
-   */
   public BuilderIndex() { }
 
-  /**
-   * Constructs the BuilderIndex instance to be stored inside GCD.
-   */
   public BuilderIndex(String name, int index) {
     this.name = name;
     this.index = index;
   }
 
-  /**
-   * @return the name of the builder.
-   */
   public String getName() {
     return name;
   }
 
-  /**
-   * @return the index of the builder.
-   */
   public int getIndex() {
     return index;
   }
 
-  /**
-   * @param name the new name of the builder
-   */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @param index the new index of the builder
-   */
   public void setIndex(int index) {
     this.index = index;
   }


### PR DESCRIPTION
Created a class to encapsulate the information needed for storing the builder index inside datastore. The primary key is the name of the builder, and it's field is the index. 

Contains all the functionality needed for Spring GCP integration (default constructor, getters and setters). Unindexed the `index` field for performance reasons.