### PR TITLE
Implementation of Index set and retrieval operations on DatastoreRepository

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -163,8 +163,7 @@ public class DatastoreRepository implements DataRepository {
     return storage.findById(commitHash, BuildInfo.class);
   }
 
-  public int getBuildbotIndex(String buildbotName) throws BuildbotNotFoundException,
-                                                          NullPointerException {
+  public int getBuildbotIndex(String buildbotName) {
     Preconditions.checkNotNull(buildbotName, "buildbotName cannot be null");
 
     BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
@@ -176,8 +175,7 @@ public class DatastoreRepository implements DataRepository {
     return associatedEntity.getIndex();
   }
 
-  public void setBuildbotIndex(String buildbotName, int newValue) throws IllegalArgumentException,
-                                                                         NullPointerException {
+  public void setBuildbotIndex(String buildbotName, int newValue) {
     Preconditions.checkNotNull(buildbotName, "buildbotName cannot be null");
 
     BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
@@ -192,8 +190,7 @@ public class DatastoreRepository implements DataRepository {
     storage.save(associatedEntity);
   }
 
-  public void registerNewBuildbot(String buildbotName, int value) throws IllegalArgumentException,
-                                                                         NullPointerException {
+  public void registerNewBuildbot(String buildbotName, int value) {
     Preconditions.checkNotNull(buildbotName, "buildbotName cannot be null");
 
     BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -202,7 +202,7 @@ public class DatastoreRepository implements DataRepository {
   /**
    * {@inheritDoc}
    */
-  public void registerNewBuildbot(String name, int value) {
+  public void registerNewBuildbot(String buildbotName, int value) {
     if (buildbotName == null) {
       throw new IllegalArgumentException("buildbotName cannot be null");
     }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -163,9 +163,6 @@ public class DatastoreRepository implements DataRepository {
     return storage.findById(commitHash, BuildInfo.class);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   public int getBuildbotIndex(String buildbotName) throws IllegalArgumentException, NotBoundException {
     if (buildbotName == null) {
       throw new IllegalArgumentException("buildbotName cannot be null");
@@ -180,9 +177,6 @@ public class DatastoreRepository implements DataRepository {
     return associatedEntity.getIndex();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   public void setBuildbotIndex(String buildbotName, int newValue) throws IllegalArgumentException,
                                                                   IndexOutOfBoundsException {
     if (buildbotName == null) {
@@ -199,9 +193,6 @@ public class DatastoreRepository implements DataRepository {
     storage.save(associatedEntity);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   public void registerNewBuildbot(String buildbotName, int value) {
     if (buildbotName == null) {
       throw new IllegalArgumentException("buildbotName cannot be null");

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -166,7 +166,7 @@ public class DatastoreRepository implements DataRepository {
   /**
    * {@inheritDoc}
    */
-  int getBuildbotIndex(String buildbotName) throws IllegalArgumentException, NotBoundException {
+  public int getBuildbotIndex(String buildbotName) throws IllegalArgumentException, NotBoundException {
     if (buildbotName == null) {
       throw new IllegalArgumentException("buildbotName cannot be null");
     }
@@ -183,7 +183,7 @@ public class DatastoreRepository implements DataRepository {
   /**
    * {@inheritDoc}
    */
-  void setBuildbotIndex(String buildbotName, int newValue) throws IllegalArgumentException,
+  public void setBuildbotIndex(String buildbotName, int newValue) throws IllegalArgumentException,
                                                                   IndexOutOfBoundsException {
     if (buildbotName == null) {
       throw new IllegalArgumentException("buildbotName cannot be null");
@@ -197,5 +197,28 @@ public class DatastoreRepository implements DataRepository {
 
     associatedEntity.setIndex(newValue);
     storage.save(associatedEntity);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public void registerNewBuildbot(String name, int value) {
+    if (buildbotName == null) {
+      throw new IllegalArgumentException("buildbotName cannot be null");
+    }
+
+    BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
+
+    if (associatedEntity == null) {
+      if (value < 0) {
+        throw new IndexOutOfBoundsException("value cannot be negative");
+      }
+
+      BuilderIndex newEntity = new BuilderIndex(name, value);
+
+      storage.save(newEntity);
+    } else if (value <= associatedEntity.getIndex()) {
+      throw new IndexOutOfBoundsException("value cannot be <= than the previous known value");
+    }
   }
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -14,11 +14,11 @@
 
 package com.google.graphgeckos.dashboard.storage;
 
-import com.google.common.base.Preconditions;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StructuredQuery.OrderBy;
+import com.google.common.base.Preconditions;
 import com.google.graphgeckos.dashboard.datatypes.BuildBotData;
 import com.google.graphgeckos.dashboard.datatypes.BuildInfo;
 import com.google.graphgeckos.dashboard.datatypes.BuilderIndex;

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -20,7 +20,9 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StructuredQuery.OrderBy;
 import com.google.graphgeckos.dashboard.datatypes.BuildBotData;
 import com.google.graphgeckos.dashboard.datatypes.BuildInfo;
+import com.google.graphgeckos.dashboard.datatypes.BuilderIndex;
 import com.google.graphgeckos.dashboard.datatypes.GitHubData;
+import java.rmi.NotBoundException;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -159,5 +161,39 @@ public class DatastoreRepository implements DataRepository {
     }
 
     return storage.findById(commitHash, BuildInfo.class);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  int getBuildbotIndex(String buildbotName) throws IllegalArgumentException, NotBoundException {
+    if (buildbotName == null) {
+      throw new IllegalArgumentException("buildbotName cannot be null");
+    }
+
+    BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
+
+    if (associatedEntity == null) {
+      throw new NotBoundException("buildbotName not bound to any index");
+    }
+
+    return associatedEntity.getIndex();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  void setBuildbotIndex(String buildbotName, int newValue) throws IllegalArgumentException,
+                                                                  IndexOutOfBoundsException {
+    if (buildbotName == null) {
+      throw new IllegalArgumentException("buildbotName cannot be null");
+    }
+
+    if (newValue <= getBuildbotIndex(buildbotName)) {
+      throw new IndexOutOfBoundsException("newValue cannot be lower than the previous index");
+    }
+
+    BuilderIndex newEntry = new BuilderIndex(buildbotName, newValue);
+    storage.save(newEntry);
   }
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -192,7 +192,7 @@ public class DatastoreRepository implements DataRepository {
     BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
 
     if (associatedEntity == null || newValue <= associatedEntity.getIndex()) {
-      throw new IndexOutOfBoundsException("newValue cannot be lower than the previous index");
+      throw new IndexOutOfBoundsException("newValue cannot be lower than or equal the previous index");
     }
 
     associatedEntity.setIndex(newValue);

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -189,11 +189,13 @@ public class DatastoreRepository implements DataRepository {
       throw new IllegalArgumentException("buildbotName cannot be null");
     }
 
-    if (newValue <= getBuildbotIndex(buildbotName)) {
+    BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
+
+    if (associatedEntity == null || newValue <= associatedEntity.getIndex()) {
       throw new IndexOutOfBoundsException("newValue cannot be lower than the previous index");
     }
 
-    BuilderIndex newEntry = new BuilderIndex(buildbotName, newValue);
-    storage.save(newEntry);
+    associatedEntity.setIndex(newValue);
+    storage.save(associatedEntity);
   }
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -184,7 +184,6 @@ public class DatastoreRepository implements DataRepository {
 
     Preconditions.checkArgument(newValue <= associatedEntity.getIndex(),
                                "newValue cannot be lower than or equal the previous index");
-    }
 
     associatedEntity.setIndex(newValue);
     storage.save(associatedEntity);
@@ -200,7 +199,7 @@ public class DatastoreRepository implements DataRepository {
     Preconditions.checkArgument(value < 0,
                                "value cannot be negative");
     
-    BuilderIndex newEntity = new BuilderIndex(name, value);
+    BuilderIndex newEntity = new BuilderIndex(buildbotName, value);
     storage.save(newEntity);
   }
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -163,8 +163,8 @@ public class DatastoreRepository implements DataRepository {
     return storage.findById(commitHash, BuildInfo.class);
   }
 
-  public int getBuildbotIndex(String buildbotName) throws IllegalArgumentException,
-                                                          BuildbotNotFoundException {
+  public int getBuildbotIndex(String buildbotName) throws BuildbotNotFoundException,
+                                                          NullPointerException {
     Preconditions.checkNotNull(buildbotName, "buildbotName cannot be null");
 
     BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
@@ -177,7 +177,7 @@ public class DatastoreRepository implements DataRepository {
   }
 
   public void setBuildbotIndex(String buildbotName, int newValue) throws IllegalArgumentException,
-                                                                  IndexOutOfBoundsException {
+                                                                         NullPointerException {
     Preconditions.checkNotNull(buildbotName, "buildbotName cannot be null");
 
     BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
@@ -192,20 +192,18 @@ public class DatastoreRepository implements DataRepository {
     storage.save(associatedEntity);
   }
 
-  public void registerNewBuildbot(String buildbotName, int value) {
+  public void registerNewBuildbot(String buildbotName, int value) throws IllegalArgumentException,
+                                                                         NullPointerException {
     Preconditions.checkNotNull(buildbotName, "buildbotName cannot be null");
 
     BuilderIndex associatedEntity = storage.findById(buildbotName, BuilderIndex.class);
 
     Preconditions.checkArgument(value <= associatedEntity.getIndex(),
                                "value cannot be <= than the previous known value");
-
-    Preconditions.checkArgument(value < 0, "value cannot be negative");
-
-    if (associatedEntity == null) {
-      BuilderIndex newEntity = new BuilderIndex(name, value);
-
-      storage.save(newEntity);
-    }
+    Preconditions.checkArgument(value < 0,
+                               "value cannot be negative");
+    
+    BuilderIndex newEntity = new BuilderIndex(name, value);
+    storage.save(newEntity);
   }
 }

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -14,6 +14,13 @@
 
 package com.google.graphgeckos.dashboard.storage;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.cloud.Timestamp;
 import com.google.graphgeckos.dashboard.datatypes.BuildInfo;
@@ -21,12 +28,10 @@ import com.google.graphgeckos.dashboard.datatypes.BuilderStatus;
 import com.google.graphgeckos.dashboard.datatypes.BuildBotData;
 import com.google.graphgeckos.dashboard.datatypes.GitHubData;
 import java.io.IOException;
-import java.rmi.NotBoundException;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.List;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,6 +50,10 @@ public class DatastoreRepositoryTests {
 
   private BuildBotData getDummyUpdate(String commitHash) {
     return new BuildBotData(commitHash, "tester", new ArrayList<>(), BuilderStatus.PASSED);
+  }
+
+  private Entity getIndexEntity(String name, int index) {
+    return Entity.Builder.newBuilder(name).set("index")
   }
 
   @Before
@@ -225,14 +234,14 @@ public class DatastoreRepositoryTests {
 
     storage.setBuildbotIndex("tester", 1000);
     
-    Assert.assertEquals(1000, storage.getBuildbotIndex("tester"));
+    assertEquals(1000, storage.getBuildbotIndex("tester"));
   }
 
   @Test
   public void testInvalidGetIndexRequest() throws IOException, InterruptedException {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
-    Assert.assertThrows(NotBoundException.class, () -> {
+    assertThrows(BuildbotNotFoundException.class, () -> {
       storage.getBuildbotIndex("tester");
     });
   }
@@ -243,11 +252,11 @@ public class DatastoreRepositoryTests {
 
     storage.setBuildbotIndex("tester", 1000);
 
-    Assert.assertThrows(IndexOutOfBoundsException.class, () -> {
+    assertThrows(IndexOutOfBoundsException.class, () -> {
       storage.setBuildbotIndex("tester", 1);
     });
 
-    Assert.assertThrows(IndexOutOfBoundsException.class, () -> {
+    assertThrows(IndexOutOfBoundsException.class, () -> {
       storage.setBuildbotIndex("tester", 1000);
     });
   }

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -112,13 +112,17 @@ public class DatastoreRepositoryTests {
       storage.deleteRevisionEntry(null);
     });
 
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(NullPointerException.class, () -> {
       storage.getBuildbotIndex(null);
     });
 
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(NullPointerException.class, () -> {
       storage.setBuildbotIndex(null, 0);
     });
+
+    assertThrows(NullPointerException.class, () -> {
+      storage.registerNewBuildbot(null, 0);
+    })
   }
 
   @Test
@@ -247,12 +251,63 @@ public class DatastoreRepositoryTests {
 
     storage.setBuildbotIndex("tester", 1000);
 
-    assertThrows(IndexOutOfBoundsException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.setBuildbotIndex("tester", 1);
     });
 
-    assertThrows(IndexOutOfBoundsException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.setBuildbotIndex("tester", 1000);
+    });
+  }
+
+  @Test
+  public void testValidRegistration() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    storage.registerNewBuildbot("test", 1);
+
+    assertEquals(1, storage.getBuildbotIndex("test"));
+  }
+
+  @Test
+  public void testAlreadyRegisteredLargerIndex() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    storage.registerNewBuildbot("test", 1);
+
+    storage.registerNewBuildbot("test", 3);
+
+    assertEquals(3, storage.getBuildbotIndex("test"));
+  }
+
+  @Test
+  public void testAlreadyRegisteredSameIndex() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    storage.registerNewBuildbot("test", 1);
+
+    storage.registerNewBuildbot("test", 1);
+
+    assertEquals(1, storage.getBuildbotIndex("test"));
+  }
+
+  @Test
+  public void testAlreadyRegisteredSmallerIndex() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    storage.registerNewBuildbot("test", 3);
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      storage.registerNewBuildbot("test", 1);
+    });
+  }
+
+    @Test
+  public void testFirstRegistrationNegative() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      storage.registerNewBuildbot("test", -1);
     });
   }
 }

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -96,27 +96,27 @@ public class DatastoreRepositoryTests {
   public void testRequestsNullData() throws IOException, InterruptedException {
     DatastoreRepository storage = new DatastoreRepository();
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.createRevisionEntry(null);
     });
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.getRevisionEntry(null);
     });
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.updateRevisionEntry(null);
     });
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.deleteRevisionEntry(null);
     });
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.getBuildbotIndex(null);
     });
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       storage.setBuildbotIndex(null, 0);
     });
   }

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -21,6 +21,7 @@ import com.google.graphgeckos.dashboard.datatypes.BuilderStatus;
 import com.google.graphgeckos.dashboard.datatypes.BuildBotData;
 import com.google.graphgeckos.dashboard.datatypes.GitHubData;
 import java.io.IOException;
+import java.rmi.NotBoundException;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.List;
@@ -105,6 +106,14 @@ public class DatastoreRepositoryTests {
 
     Assert.assertThrows(IllegalArgumentException.class, () -> {
       storage.deleteRevisionEntry(null);
+    });
+
+    Assert.assertThrows(IllegalArgumentException.class, () -> {
+      storage.getBuildbotIndex(null);
+    });
+
+    Assert.assertThrows(IllegalArgumentException.class, () -> {
+      storage.setBuildbotIndex(null, 0);
     });
   }
 
@@ -208,5 +217,34 @@ public class DatastoreRepositoryTests {
     Assert.assertEquals(results.size(), 2);
     Assert.assertEquals(results.get(0), dummy2);
     Assert.assertEquals(results.get(1), dummy1);
+  }
+
+  @Test
+  public void testValidGetAndSetIndexRequests() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    storage.setBuildbotIndex("tester", 1000);
+    
+    Assert.assertEquals(1000, storage.getBuildbotIndex("tester"));
+  }
+
+  @Test
+  public void testInvalidGetIndexRequest() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    Assert.assertThrows(NotBoundException.class, () -> {
+      storage.getBuildbotIndex("tester");
+    });
+  }
+
+  @Test
+  public void testInvalidSetIndexRequest() throws IOException, InterruptedException {
+    DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
+
+    storage.setBuildbotIndex("tester", 1000);
+
+    Assert.assertThrows(IndexOutOfBoundsException.class, () -> {
+      storage.setBuildbotIndex("tester", 1);
+    });
   }
 }

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -246,5 +246,9 @@ public class DatastoreRepositoryTests {
     Assert.assertThrows(IndexOutOfBoundsException.class, () -> {
       storage.setBuildbotIndex("tester", 1);
     });
+
+    Assert.assertThrows(IndexOutOfBoundsException.class, () -> {
+      storage.setBuildbotIndex("tester", 1000);
+    });
   }
 }

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.cloud.Timestamp;
 import com.google.graphgeckos.dashboard.datatypes.BuildInfo;
@@ -50,10 +49,6 @@ public class DatastoreRepositoryTests {
 
   private BuildBotData getDummyUpdate(String commitHash) {
     return new BuildBotData(commitHash, "tester", new ArrayList<>(), BuilderStatus.PASSED);
-  }
-
-  private Entity getIndexEntity(String name, int index) {
-    return Entity.Builder.newBuilder(name).set("index")
   }
 
   @Before


### PR DESCRIPTION
Implemented the `getBuildbotIndex` and `setBuildbotIndex` methods described by `DataRepository` in #121.

Since the user of these functions should not have to handle `BuilderIndex` (#123), the implementation for `getBuildbotIndex` had to handle the situation where there is no entry associated to the given builder name. The solution I chose was to throw a [NotBoundException](https://docs.oracle.com/javase/8/docs/api/java/rmi/NotBoundException.html), since it seemed like the most closely related predefined exception for this specific case.

Since `getBuildbotIndex` throws an exception when there is no entry associated to the given name, the elegant solution is for `setBuildbotIndex` to not use it for retrieval of the previous index value.