### PR TITLE
Pass Navigation Options to Navigation Component Instance

### DIFF
--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -1,6 +1,17 @@
 import * as React from "react";
 import { Navigation } from "./Navigation";
 
+const OPTIONS = [
+  {
+    text: 'Docs',
+    link:  'https://github.com/googleinterns/step240-2020'
+  },
+  {
+    text: 'Buildbot',
+    link: 'http://lab.llvm.org:8011/'
+  }
+];
+
 /**
  * Main Navigation Component
  */
@@ -13,7 +24,7 @@ export const Header = () => {
         <span className='title'>{TITLE}</span>
       </div>
       <div>
-        <Navigation/>
+        <Navigation options={OPTIONS}/>
       </div>
     </header>
   );

--- a/src/main/webapp/components/Header.js
+++ b/src/main/webapp/components/Header.js
@@ -4,7 +4,7 @@ import { Navigation } from "./Navigation";
 const OPTIONS = [
   {
     text: 'Docs',
-    link:  'https://github.com/googleinterns/step240-2020'
+    link: 'https://github.com/googleinterns/step240-2020'
   },
   {
     text: 'Buildbot',

--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -27,8 +27,8 @@ const NavigationItem = (props) => {
 export const Navigation = (props) => {
   return (
     <ul className="navigation">
-      {props.options.map (option => 
-          <NavigationItem href={option.link} innerText={option.text}/>
+      {props.options.map (option, idx => 
+          <NavigationItem key={idx} href={option.link} innerText={option.text}/>
       )}
     </ul>
   );

--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -27,7 +27,7 @@ const NavigationItem = (props) => {
 export const Navigation = (props) => {
   return (
     <ul className="navigation">
-      {props.options.map (option, idx => 
+      {props.options.map((option, idx) => 
           <NavigationItem key={idx} href={option.link} innerText={option.text}/>
       )}
     </ul>


### PR DESCRIPTION
This PR passes the navigation options to the instance of the Navigation Component, nested in the Header.

- Resolves a 'undefined' error resulting from an undefined prop.
- Sets key property of generated NavigationItems, to suppress undefined key warning.
