### PR TITLE
Rename Prop to Match Expected Name

### DIFF
--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -24,7 +24,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
 
     return (
       <div>
-        {data.map(snapshotData => <BuildSnapshot data={snapshotData}/>)}
+        {data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)}
       </div>
     );
   }


### PR DESCRIPTION
This PR rectifies a mismatch between the prop through which the build data is passed to the BuildSnapshot component (<code>data</code>) and prop from which it expected the data (<code>buildData</code>).

This will fix undefined errors resulting from the mismatch.