### PR TITLE
Include BuilderDataTable and Incoming BuilderGrid

### DIFF
--- a/src/main/webapp/components/BuildSnapshot.js
+++ b/src/main/webapp/components/BuildSnapshot.js
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import {BuilderDataTable} from './BuilderDataTable';
+import {BuilderGrid} from './BuilderGrid';
 import {getFields} from './utils/getFields.js';
 
 /**


### PR DESCRIPTION
This PR integrates two missing imports for the BuildSnapshot Component, namely <code>BuilderDataTable</code>, <code>BuilderGrid</code>, which are components used in the Tray.