### PR TITLE
Add abstract class for golden file testing

### DIFF
--- a/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
@@ -1,0 +1,51 @@
+package com.google.graphgeckos.dashboard;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+
+/** Provides functionality to perform golden file testing. */
+public abstract class AbstractJsonTestInfo {
+
+  /** Returns path to the folder with the files (inputs and expected outputs) for testing. */
+  protected abstract String getPath();
+
+  /** The file names for one test differ only in prefixes. E.g input_real_json.txt and output_real_json.txt. */
+  protected static final String INPUT_PREFIX = "input_";
+  protected static final String EXPECTED_PREFIX = "output_";
+
+  /** Inputs and expected outputs are stored as txt files. */
+  protected static final String FILE_FORMAT = ".txt";
+
+  /** Test input (json). */
+  protected String content;
+
+  protected String readFile(String filePath) throws IOException {
+    return Files.lines(Paths.get(filePath)).collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * The expected output for each test is stored as a txt file. One line for each field.
+   * The order of the values is described in inherited classes.
+   *
+   * @param expected Lines of the expected output file for the test.
+   */
+  protected abstract void assignExpectedValues(String[] expected);
+
+  public AbstractJsonTestInfo(String testName) {
+    try {
+      content = readFile(getPath() + INPUT_PREFIX + testName + FILE_FORMAT);
+    } catch (IOException e) {
+      System.out.println("File not found:" + e.getMessage());
+    }
+    try {
+      String[] expected = readFile(getPath() + EXPECTED_PREFIX + testName + FILE_FORMAT).split("\n");
+      assignExpectedValues(expected);
+    } catch (IOException e) {
+      System.out.println("File not found:" + e.getMessage());
+    }
+  }
+
+}

--- a/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
@@ -32,6 +32,7 @@ public abstract class AbstractJsonTestInfo {
     } catch (IOException e) {
       System.out.println("File not found:" + e.getMessage());
     }
+    
     try {
       String[] expected = readFile(getPath() + EXPECTED_PREFIX + testName + FILE_FORMAT).split("\n");
       assignExpectedValues(expected);

--- a/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
@@ -32,7 +32,7 @@ public abstract class AbstractJsonTestInfo {
     } catch (IOException e) {
       System.out.println("File not found:" + e.getMessage());
     }
-    
+
     try {
       String[] expected = readFile(getPath() + EXPECTED_PREFIX + testName + FILE_FORMAT).split("\n");
       assignExpectedValues(expected);

--- a/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
@@ -34,6 +34,10 @@ public abstract class AbstractJsonTestInfo {
    */
   protected abstract void assignExpectedValues(String[] expected);
 
+  /**
+   * @param testName Common part of the input and output file names. E.g the test name "real_json" is expected
+   *                to have input_real_json.txt file with input json and output_real_json.txt with expected output.
+   */
   public AbstractJsonTestInfo(String testName) {
     try {
       content = readFile(getPath() + INPUT_PREFIX + testName + FILE_FORMAT);

--- a/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/AbstractJsonTestInfo.java
@@ -22,18 +22,6 @@ public abstract class AbstractJsonTestInfo {
   /** Test input (json). */
   protected String content;
 
-  protected String readFile(String filePath) throws IOException {
-    return Files.lines(Paths.get(filePath)).collect(Collectors.joining("\n"));
-  }
-
-  /**
-   * The expected output for each test is stored as a txt file. One line for each field.
-   * The order of the values is described in inherited classes.
-   *
-   * @param expected Lines of the expected output file for the test.
-   */
-  protected abstract void assignExpectedValues(String[] expected);
-
   /**
    * @param testName Common part of the input and output file names. E.g the test name "real_json" is expected
    *                to have input_real_json.txt file with input json and output_real_json.txt with expected output.
@@ -51,5 +39,17 @@ public abstract class AbstractJsonTestInfo {
       System.out.println("File not found:" + e.getMessage());
     }
   }
+
+  protected String readFile(String filePath) throws IOException {
+    return Files.lines(Paths.get(filePath)).collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * The expected output for each test is stored as a txt file. One line for each field.
+   * The order of the values is described in inherited classes.
+   *
+   * @param expected Lines of the expected output file for the test.
+   */
+  protected abstract void assignExpectedValues(String[] expected);
 
 }

--- a/src/test/java/com/google/graphgeckos/dashboard/GitHubJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/GitHubJsonTestInfo.java
@@ -1,27 +1,17 @@
 package com.google.graphgeckos.dashboard;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.stream.Collectors;
-
 /**
  * Represents input and expected output for a test. Used in {@see GitHubControllerTest}.
  */
-public class GitHubJsonTestInfo {
+public class GitHubJsonTestInfo extends AbstractJsonTestInfo {
 
-  // Path to the folder with the files (inputs and expected outputs) for testing.
-  private static final String PATH = "src/test/resources/jsons/";
-
-  // The file names for one test differ only in prefixes. E.g input_real_json.txt and output_real_json.txt.
-  private static final String INPUT_PREFIX = "input_";
-  private static final String EXPECTED_PREFIX = "output_";
-
-  // Inputs and expected outputs are stored as txt files.
-  private static final String FILE_FORMAT = ".txt";
-
-  // Test input (json).
-  private String content;
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected String getPath() {
+    return "src/test/resources/jsons/";
+  }
 
   // Expected output fields. See com.google.graphgeckos.dashboard.GitHubData class to learn more.
   private String branch;
@@ -29,16 +19,14 @@ public class GitHubJsonTestInfo {
   private String timestamp;
   private String repositoryLink;
 
-  private String readFile(String filePath) throws IOException {
-    return Files.lines(Paths.get(filePath)).collect(Collectors.joining("\n"));
-  }
-
   /**
-   * The expected output of each test is stored as a txt file with four lines. Values come in the following order:
-   * branch, commit hash, timestamp, repository link.
+   * {@inheritDoc}
+   * Values come in the following order: branch, commit hash, timestamp, repository link.
+   *
    * @param expected Lines of the expected output file for the test.
    */
-  private void assignExpectedValues(String[] expected) {
+  @Override
+  protected void assignExpectedValues(String[] expected) {
     if (expected.length < 4) {
       throw new IllegalArgumentException(
         String.format("Wrong file format, expected four lines, found %d", expected.length));
@@ -54,17 +42,7 @@ public class GitHubJsonTestInfo {
    *                to have input_real_json.txt file with input json and output_real_json.txt with expected output.
    */
   public GitHubJsonTestInfo(String testName) {
-    try {
-      content = readFile(PATH + INPUT_PREFIX + testName + FILE_FORMAT);
-    } catch (IOException e) {
-      System.out.println("File not found:" + e.getMessage());
-    }
-    try {
-      String[] expected = readFile(PATH + EXPECTED_PREFIX + testName + FILE_FORMAT).split("\n");
-      assignExpectedValues(expected);
-    } catch (IOException e) {
-      System.out.println("File not found:" + e.getMessage());
-    }
+    super(testName);
   }
 
   /**

--- a/src/test/java/com/google/graphgeckos/dashboard/GitHubJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/GitHubJsonTestInfo.java
@@ -37,9 +37,9 @@ public class GitHubJsonTestInfo extends AbstractJsonTestInfo {
     repositoryLink = expected[3];
   }
 
+
   /**
-   * @param testName Common part of the input and output file names. E.g the test name "real_json" is expected
-   *                to have input_real_json.txt file with input json and output_real_json.txt with expected output.
+   * {@inheritDoc}
    */
   public GitHubJsonTestInfo(String testName) {
     super(testName);

--- a/src/test/java/com/google/graphgeckos/dashboard/GitHubJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/GitHubJsonTestInfo.java
@@ -5,6 +5,19 @@ package com.google.graphgeckos.dashboard;
  */
 public class GitHubJsonTestInfo extends AbstractJsonTestInfo {
 
+  // Expected output fields. See com.google.graphgeckos.dashboard.GitHubData class to learn more.
+  private String branch;
+  private String commitHash;
+  private String timestamp;
+  private String repositoryLink;
+
+  /**
+   * {@inheritDoc}
+   */
+  public GitHubJsonTestInfo(String testName) {
+    super(testName);
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -12,12 +25,6 @@ public class GitHubJsonTestInfo extends AbstractJsonTestInfo {
   protected String getPath() {
     return "src/test/resources/jsons/";
   }
-
-  // Expected output fields. See com.google.graphgeckos.dashboard.GitHubData class to learn more.
-  private String branch;
-  private String commitHash;
-  private String timestamp;
-  private String repositoryLink;
 
   /**
    * {@inheritDoc}
@@ -35,14 +42,6 @@ public class GitHubJsonTestInfo extends AbstractJsonTestInfo {
     commitHash = expected[1];
     timestamp = expected[2];
     repositoryLink = expected[3];
-  }
-
-
-  /**
-   * {@inheritDoc}
-   */
-  public GitHubJsonTestInfo(String testName) {
-    super(testName);
   }
 
   /**

--- a/src/test/java/com/google/graphgeckos/dashboard/github/GitHubJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/github/GitHubJsonTestInfo.java
@@ -1,5 +1,7 @@
 package com.google.graphgeckos.dashboard.github;
 
+import com.google.graphgeckos.dashboard.AbstractJsonTestInfo;
+
 /**
  * Represents input and expected output for a test. Used in {@see GitHubControllerTest}.
  */


### PR DESCRIPTION
Since JSONs are used for testing fetchers, it's nice to have convenient tool to easily access these input and expected outputs and store them in files instead of having long hardcoded Strings. 
The ```AbstractJsonTestInfo``` class contains common methods of the already implemented ```GitHubJsonTestInfo``` and ```BuildBotJsonTestInfo``` which will be implemented in the future PR. The last mentioned class is required to test a BuildBot fetcher.