### PR TITLE
Change Target Element to Body

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -4,8 +4,7 @@
     <link rel="stylesheet" href="./style.css">
   </head>
 
-  <body>
-    <div id="root"></div>
+  <body id="root">
     <script defer src="./index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR changes the target element which React renders our component to from a <code>div</code> to the main <code>body</code> element.
This changes was made to simplify our DOM structure.
Prior to the change, we would have a structure of **html > body > div > content**
With this change, this is simplified to **html > body > content**

This also means the body will have to be styled accordingly to be treated as a container. See PR #137. 