### PR TITLE
Add missing case to getField

### DIFF
--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -7,7 +7,9 @@
  * @param defaultValue the value to be used if obj[field] === undefined.
  */
 export const getField = (obj, field, defaultValue) => {
-  return obj[field] !== undefined ?
+  return obj !== undefined ? 
+      obj[field] !== undefined ?
       obj[field] :
-      (defaultValue !== undefined ? defaultValue : null);
+      (defaultValue !== undefined ? defaultValue : null) :
+      defaultValue;
 }

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -10,6 +10,6 @@ export const getField = (obj, field, defaultValue) => {
   return obj !== undefined ? 
       obj[field] !== undefined ?
       obj[field] :
-      (defaultValue !== undefined ? defaultValue : null) :
-      defaultValue;
+          (defaultValue !== undefined ? defaultValue : null) :
+          defaultValue;
 }

--- a/src/main/webapp/components/utils/getField.js
+++ b/src/main/webapp/components/utils/getField.js
@@ -7,9 +7,9 @@
  * @param defaultValue the value to be used if obj[field] === undefined.
  */
 export const getField = (obj, field, defaultValue) => {
-  return obj !== undefined ? 
-      obj[field] !== undefined ?
-      obj[field] :
-          (defaultValue !== undefined ? defaultValue : null) :
-          defaultValue;
+  return obj !== undefined
+             ? obj[field] !== undefined
+                   ? obj[field]
+                   : (defaultValue !== undefined ? defaultValue : null)
+             : defaultValue;
 }


### PR DESCRIPTION
This PR integrates a missing check in the getField method. 
Before, the <code>obj</code> param wasn't checked to be undefined, and so it was possible to get an error when trying to check obj[field] if obj === undefined.
The fix here is to first check if obj === undefined.