### PR TITLE
Use getField to Fetch Props

### DIFF
--- a/src/main/webapp/components/BuilderDataTable.js
+++ b/src/main/webapp/components/BuilderDataTable.js
@@ -27,7 +27,7 @@ export const BuilderDataTable = props => {
         <tr>{HEADERS.map(header => <th>{header}</th>)}</tr>
       </thead>
       <tbody>
-        {props.buildSteps.map(datapoint => 
+        {buildSteps.map(datapoint => 
           <tr>
             {BUILD_STEP_FIELDS.map(field => <td>{datapoint[field]}</td>)}
           </tr>

--- a/src/main/webapp/components/BuilderDataTable.js
+++ b/src/main/webapp/components/BuilderDataTable.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {getFields} from './utils/getFields.js';
 
 // The target fields to be extracted from each build step
 // and displayed on each row.
@@ -18,6 +19,8 @@ const HEADERS = ['no.', 'text', 'log'];
  * @param {string} props.buildSteps[].logs - A URL pointing to the log file.
  */
 export const BuilderDataTable = props => {
+  const buildSteps = getField(props, 'buildSteps', []);
+
   return (
     <table className='data-table'>
       <thead>

--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {getField} from "./utils/getField";
 
 /**
  * Main List Element to be displayed on the Navigation.
@@ -26,7 +27,7 @@ const NavigationItem = (props) => {
   */
 export const Navigation = (props) => {
   const options = getField(props, 'options', []);
-  
+
   return (
     <ul className="navigation">
       {props.options.map (option => 

--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -25,6 +25,8 @@ const NavigationItem = (props) => {
   * @param {string} props.options[].text the displayed text for the option.
   */
 export const Navigation = (props) => {
+  const options = getField(props, 'options', []);
+  
   return (
     <ul className="navigation">
       {props.options.map (option => 

--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -30,7 +30,7 @@ export const Navigation = (props) => {
 
   return (
     <ul className="navigation">
-      {props.options.map (option => 
+      {options.map (option => 
           <NavigationItem href={option.link} innerText={option.text}/>
       )}
     </ul>


### PR DESCRIPTION
This PR makes use of the getField utility to safely fetch fields from the props object passed to React components.
This change is beneficial because it prevents the possibility of an unsuspecting 'undefined' error when fetching nested attributes.