### PR TITLE
Fix test failure for deleteRevisionEntry

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -133,11 +133,9 @@ public class DatastoreRepository implements DataRepository {
 
         return false;
       }
-
-      return true;
     }
 
-    return false;
+    return true;
   }
 
   /**


### PR DESCRIPTION
Changed the return value, in case there is no revision with that certain commit hash to delete, to true. The reasoning is that, in the sense of having the end result accomplished (to have the entry with that commit hash no longer in the datastore), deleting the entry, or not having the entry at all, are virtually the same.