### PR TITLE
Add equals method to BuildBotData

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -121,6 +121,9 @@ public class BuildBotData {
     this.timestamp = timestamp;
   }
 
+  /**
+   * Checks if all non-transient fields are equal between BuildBotData instances.
+   */
   @Override
   public boolean equals(Object o) {
     if (o == null || !(o instanceof BuildBotData)) {
@@ -128,8 +131,8 @@ public class BuildBotData {
     }
 
     BuildBotData other = (BuildBotData) o;
-    return commitHash.equals(other.commitHash) && timestamp.equals(other.timestamp) &&
-           name.equals(other.name) && logs.equals(other.logs) && status.equals(other.status);
+    return timestamp.equals(other.timestamp) && name.equals(other.name) &&
+           logs.equals(other.logs) && status.equals(other.status);
   }
 
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -121,4 +121,15 @@ public class BuildBotData {
     this.timestamp = timestamp;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || !(o instanceof BuildBotData)) {
+      return false;
+    }
+
+    BuildBotData other = (BuildBotData) o;
+    return commitHash.equals(other.commitHash) && timestamp.equals(other.timestamp) &&
+           name.equals(other.name) && logs.equals(other.logs) && status.equals(other.status);
+  }
+
 }


### PR DESCRIPTION
Since BuildInfo's equals method depends on the equals method in BuildBotData, DatastoreRepository couldn't be tested properly, making the updateRevisionEntry test fail. This PR adds a concise `equals` method for BuildBotData, fixing the test failure.

The method doesn't check for equality between the commit hash fields, since it's marked as transient for the datastore, as such, there is no guarantee that there is valid data inside of it when retrieving the object.