### PR TITLE
Return builder status enum

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderStatus.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderStatus.java
@@ -15,7 +15,7 @@
 package com.google.graphgeckos.dashboard.datatypes;
 
 /**
- * Represents buildbot statuses.
+ * Represents BuildBot statuses.
  */
 public enum BuilderStatus {
   FAILED,

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderStatus.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuilderStatus.java
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.graphgeckos.dashboard.datatypes;
+
+/**
+ * Represents buildbot statuses.
+ */
+public enum BuilderStatus {
+  FAILED,
+  PASSED,
+  LOST;
+}


### PR DESCRIPTION
BuilderStatus enum was accidentally deleted in one of the previous PRs. This PR brings back the newest version of it.