### PR TITLE
Fix maven duplicate dependency warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,17 +55,14 @@
       <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test-autoconfigure</artifactId>
       <version>2.3.3.RELEASE</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>


### PR DESCRIPTION
When deploying, Maven was printing out a warning about a duplicated dependency: jUnit. This PR removes the duplicate from pom.xml