### PR TITLE
Remove final modifier of non-final variable log

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildBotData.java
@@ -56,7 +56,7 @@ public class BuildBotData {
    * The logs of each compilation stage, stored as described by {@link Log}.
    */
   @Field(name = "logs")
-  private final List<Log> logs = new ArrayList<>();
+  private List<Log> logs = new ArrayList<>();
 
   /**
    * Builder compilation status, as described by {@link BuilderStatus}.


### PR DESCRIPTION
Fixed the compilation failure described above.

Final fields don't have setters.