### PR TITLE
Catch GET Request errors and Change Target Endpoint

### DIFF
--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -19,7 +19,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
      * @see <a href="www.robinwieruch.de/react-hooks-fetch-data">Fetching</a>
      */
     React.useEffect(() => {
-      fetch(SOURCE).then(res => setData(res.json()));
+      fetch(SOURCE).then(res => setData(res.json())).catch(setData([]));
     }, []);
 
     return (

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -9,7 +9,7 @@ import {BuildSnapshot} from "./BuildSnapshot";
  */
 export const BuildSnapshotContainer = React.memo((props) =>
   {
-    const SOURCE = '/data';
+    const SOURCE = '/builders';
     const [data, setData] = React.useState([]);
 
     /**

--- a/src/main/webapp/package-lock.json
+++ b/src/main/webapp/package-lock.json
@@ -179,7 +179,6 @@
       "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.10.4",
         "@babel/types": "^7.10.4"
       }
     },
@@ -278,7 +277,6 @@
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-wrap-function": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
         "@babel/types": "^7.10.4"
       }
     },


### PR DESCRIPTION
This PR adds a .catch at the end of the promise change in case no valid JSON in received.
This PR also changes the target endpoint from /data to /builders, since this is where we send the data from.

See #127 for endpoint information.