### PR TITLE
Add equals method to Log

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/Log.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/Log.java
@@ -62,4 +62,14 @@ public class Log {
     this.link = link;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || !(o instanceof Log)) {
+      return false;
+    }
+
+    Log other = (Log) o;
+    return type.equals(other.type) && link.equals(other.link);
+  }
+
 }


### PR DESCRIPTION
Since BuildInfo::equals calls BuildBotData::equals which calls Log::equals is needed in the DatastoreRepository tests, and Log::equals is missing, this caused one test to fail. This PR adds the equals method to the Log class, and fixes the test failure.