### PR TITLE
Remove unintended comparisons in equals method

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
@@ -136,8 +136,7 @@ public class BuildInfo {
       return false;
     }
     BuildInfo other = (BuildInfo) o;
-    return commitHash.equals(other.commitHash) && timestamp.equals(other.timestamp) &&
-           branch.equals(other.branch) && builders.equals(other.builders);
+    return commitHash.equals(other.commitHash) && timestamp.equals(other.timestamp);
   }
 
 }


### PR DESCRIPTION
BuildInfo::equals was comparing fields annotated as `@Unindexed`, which led to unspecified behaviour. Removed the comparisons with those fields.