### PR TITLE
enable @Autowired for DatastoreRepository

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -32,8 +32,6 @@ import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
 import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreServiceObjectToKeyFactory;
 import org.springframework.cloud.gcp.data.datastore.core.convert.DefaultDatastoreEntityConverter;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
@@ -70,6 +68,9 @@ public class DatastoreRepository implements DataRepository {
     storage = new DatastoreTemplate(supplier, entityConverter, mappingContext, objectToKeyFactory);
   }
 
+  public DatastoreRepository() {
+    this(new DefaultDatastoreFactory().create(DatastoreOptions.getDefaultInstance()));
+  }
 
   /**
    * {@inheritDoc}
@@ -175,15 +176,5 @@ public class DatastoreRepository implements DataRepository {
     Objects.requireNonNull(commitHash);
 
     return storage.findById(commitHash, BuildInfo.class);
-  }
-}
-
-@Configuration
-class DatastoreRepositoryConfig {
-  DefaultDatastoreFactory datastoreFactory = new DefaultDatastoreFactory();
-
-  @Bean
-  DatastoreRepository datastoreRepository() {
-    return new DatastoreRepository(datastoreFactory.create(DatastoreOptions.getDefaultInstance()));
   }
 }

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -16,6 +16,8 @@ package com.google.graphgeckos.dashboard.storage;
 
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.DatastoreOptions.DefaultDatastoreFactory;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StructuredQuery.OrderBy;
@@ -30,6 +32,8 @@ import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
 import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreServiceObjectToKeyFactory;
 import org.springframework.cloud.gcp.data.datastore.core.convert.DefaultDatastoreEntityConverter;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
@@ -171,5 +175,15 @@ public class DatastoreRepository implements DataRepository {
     Objects.requireNonNull(commitHash);
 
     return storage.findById(commitHash, BuildInfo.class);
+  }
+}
+
+@Configuration
+class DatastoreRepositoryConfig {
+  DefaultDatastoreFactory datastoreFactory = new DefaultDatastoreFactory();
+
+  @Bean
+  DatastoreRepository datastoreRepository() {
+    return new DatastoreRepository(datastoreFactory.create(DatastoreOptions.getDefaultInstance()));
   }
 }


### PR DESCRIPTION
Added a `@Configuration` class for integration with Spring's `@Autowired` annotation, so that Spring can correctly instance DatastoreRepository autowired objects. Returns a DatastoreRepository instanced using a Datastore, with default Datastore options. It is possible that we might need to add some sort of credentials to the options, but this will be seen when testing the endpoint.