### PR TITLE
Replace mvn deploy command with gcloud deploy in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 gcloud config set project llvm-build-dashboard &&
-mvn package com.google.cloud.tools:appengine-maven-plugin:deploy
+mvn clean package &&
+gcloud app deploy target/step240-2020-1.0.jar


### PR DESCRIPTION
This PR replaces the old mvn deploy command with the manual deployment steps.

- <code>mvn clean package</code> builds the application
- <code>gcloud app deploy</code> deploys the application on gcloud.