### PR TITLE
Style BuildSnapshot Container

### DIFF
--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -36,7 +36,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
     }, []);
 
     return (
-      <div>
+      <div className='buildsnapshot-container'>
         {data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)}
       </div>
     );

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -36,7 +36,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
     }, []);
 
     return (
-      <div className='buildsnapshot-container'>
+      <div className='build-snapshot-container'>
         {data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)}
       </div>
     );

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -36,7 +36,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
     }, []);
 
     return (
-      <div className='build-snapshot-container'>
+      <div id='build-snapshot-container'>
         {data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)}
       </div>
     );

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -49,6 +49,13 @@ ul {
   background-color: var(--failed);
 }
 
+.build-snapshot-container {
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .snapshot-header {
   align-items: center;
   border: 0.25rem var(--primary) solid;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -49,7 +49,7 @@ ul {
   background-color: var(--failed);
 }
 
-.build-snapshot-container {
+#build-snapshot-container {
   background: transparent;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This PR integrates the styling for the BuildSnapshot Container.

- **Displays container as a flex column**
- **Add gap to 1rem**

It was decided to set this as an ID as it is intended for there to be only one instance of the buildsnapshot container.