### PR TITLE
Include missing import from BuilderDataTable

### DIFF
--- a/src/main/webapp/components/BuilderDataTable.js
+++ b/src/main/webapp/components/BuilderDataTable.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {getFields} from './utils/getFields.js';
+import {getField} from './utils/getField.js';
 
 // The target fields to be extracted from each build step
 // and displayed on each row.


### PR DESCRIPTION
This PR imports getField rather than getFields, fixing the missing import.