### PR TITLE
Refactor Header Style and Move Border Rule to Wrapper

### DIFF
--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -53,7 +53,6 @@ ul {
 .snapshot-header {
   align-items: center;
   border: 0.25rem var(--primary) solid;
-  border-radius: 0.5rem;
   color: var(--primary);
   display: flex;
   gap: 1rem;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -34,6 +34,7 @@ ul {
   padding: 0 2rem;
   text-decoration: underline;
 }
+
 .build-snapshot {
   color: var(--primary);
   border-radius: 1rem;
@@ -52,7 +53,6 @@ ul {
 .snapshot-header {
   align-items: center;
   border: 0.25rem var(--primary) solid;
-  box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.25);
   border-radius: 0.5rem;
   color: var(--primary);
   display: flex;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -53,7 +53,6 @@ ul {
 
 .snapshot-header {
   align-items: center;
-  border-bottom: 0.25rem var(--primary) solid;
   color: var(--primary);
   display: flex;
   gap: 1rem;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -37,7 +37,8 @@ ul {
 
 .build-snapshot {
   color: var(--primary);
-  border-radius: 1rem;
+  border: 0.25rem var(--primary) solid;
+  border-radius: 0.5rem;
   flex: 1;
   font-size: 1rem;
 }
@@ -52,7 +53,6 @@ ul {
 
 .snapshot-header {
   align-items: center;
-  border: 0.25rem var(--primary) solid;
   color: var(--primary);
   display: flex;
   gap: 1rem;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -53,6 +53,7 @@ ul {
 
 .snapshot-header {
   align-items: center;
+  border-bottom: 0.25rem var(--primary) solid;
   color: var(--primary);
   display: flex;
   gap: 1rem;


### PR DESCRIPTION
This PR removes the box shadow from the BuildSnapshot Header and moves the border rule to the BuildSnapshot Top-Level element.

Update: The border rule has been removed and has been changed to conditionally appear. See PR #175 