### PR TITLE
Add User Feedback for Results of Fetch

### DIFF
--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -37,7 +37,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
 
     let content;
     if (data.length > 0) {
-      content = data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)
+      content = data.map(snapshot => <BuildSnapshot buildData={snapshot}/>);
     } else {
       content = <span className='loader'>
           No new revisions to display as of {new Date().toString()}.</span>;

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -40,7 +40,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
       content = data.map(snapshot => <BuildSnapshot buildData={snapshot}/>);
     } else {
       content = <span className='loader'>
-          No new revisions to display as of {new Date().toString()}.</span>;
+          No new revisions to display as of {new Date().toLocaleString()}.</span>;
     }
 
     return (

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -35,11 +35,12 @@ export const BuildSnapshotContainer = React.memo((props) =>
         .catch(setData([]));
     }, []);
 
-    const content = <span className='loader'>
-        No new revisions to display, {new Date().toString()}.</span>;
-
+    let content;
     if (data.length > 0) {
       content = data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)
+    } else {
+      content = <span className='loader'>
+          No new revisions to display as of {new Date().toString()}.</span>;
     }
 
     return (

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -35,11 +35,16 @@ export const BuildSnapshotContainer = React.memo((props) =>
         .catch(setData([]));
     }, []);
 
-    const content = <span>No new revisions to display ({new Date().toString()}).</span>
-    
+    const content = <span className='loader'>
+        No new revisions to display, {new Date().toString()}.</span>;
+
+    if (data.length > 0) {
+      content = data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)
+    }
+
     return (
       <div id='build-snapshot-container'>
-        {data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)}
+        {content}
       </div>
     );
   }

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -35,6 +35,8 @@ export const BuildSnapshotContainer = React.memo((props) =>
         .catch(setData([]));
     }, []);
 
+    const content = <span>No new revisions to display ({new Date().toString()}).</span>
+    
     return (
       <div id='build-snapshot-container'>
         {data.map(snapshotData => <BuildSnapshot buildData={snapshotData}/>)}

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -113,3 +113,8 @@ ul {
   font-style: italic;
   text-transform: uppercase;
 }
+
+.loader {
+  padding: 1rem 0;
+  text-align: center;
+}

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -114,6 +114,7 @@ ul {
   text-transform: uppercase;
 }
 
+/* Message Element in BuildSnapshot Container*/
 .loader {
   padding: 1rem 0;
   text-align: center;


### PR DESCRIPTION
This PR integrates some feedback to the user in the case that no data is received from the API.
Previously, users would get an empty screen. Now, they are provided a prompt telling them no data has been received.

![image](https://user-images.githubusercontent.com/47117318/93596902-0c0e9a80-f9b2-11ea-9ab5-35f461ca33c5.png)
