### PR TITLE
Integrate GitHub fetcher with the storage

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/fetchers/github/GitHubController.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/fetchers/github/GitHubController.java
@@ -1,6 +1,8 @@
 package com.google.graphgeckos.dashboard.fetchers.github;
 
 import com.google.graphgeckos.dashboard.datatypes.GitHubData;
+import com.google.graphgeckos.dashboard.storage.DatastoreRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -9,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class GitHubController {
 
+  @Autowired
+  private DatastoreRepository datastoreRepository;
+
   /**
    * Handles POST requests from the GitHub API. Setting GitHub Webhooks is required.
    * Extracts required data from the json {@see CommitData} and adds it to the Storage.
@@ -16,7 +21,7 @@ public class GitHubController {
    */
   @RequestMapping(value = "/github-info", method = RequestMethod.POST, headers = {"content-type=application/json"})
   public GitHubData postGitHubInfo(@RequestBody GitHubData gitHubData) {
-    // TODO(issue #64): Implement described functionality.
+    datastoreRepository.createRevisionEntry(gitHubData);
     return gitHubData;
   }
 

--- a/src/main/java/com/google/graphgeckos/dashboard/fetchers/github/GitHubController.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/fetchers/github/GitHubController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class GitHubController {
 
+  /** Provides access to the storage. */
   @Autowired
   private DatastoreRepository datastoreRepository;
 

--- a/src/test/java/com/google/graphgeckos/dashboard/github/GitHubControllerTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/github/GitHubControllerTests.java
@@ -3,12 +3,18 @@ package com.google.graphgeckos.dashboard.github;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import com.google.graphgeckos.dashboard.datatypes.GitHubData;
 import com.google.graphgeckos.dashboard.fetchers.github.GitHubController;
+import com.google.graphgeckos.dashboard.storage.DatastoreRepository;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -22,6 +28,14 @@ public class GitHubControllerTests {
 
   @Autowired
   private MockMvc mvc;
+
+  @MockBean
+  private DatastoreRepository datastoreRepository;
+
+  @Before
+  public void init() {
+    MockitoAnnotations.initMocks(this);
+  }
 
   private final GitHubJsonTestInfo JSON_WITHOUT_UNKNOWN_FIELDS =
     new GitHubJsonTestInfo("no_unknown_fields_json");
@@ -53,6 +67,16 @@ public class GitHubControllerTests {
       .andExpect(jsonPath("commitHash").value(REAL_JSON.getCommitHash()))
       .andExpect(jsonPath("timestamp").value(REAL_JSON.getTimestamp()))
       .andExpect(jsonPath("repositoryLink").value(REAL_JSON.getRepositoryLink()));
+  }
+
+  @Test
+  public void controllerAttemptsToAddFetchedGitHubDataToTheStorage() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.post("/github-info")
+       .contentType("application/json")
+       .content(REAL_JSON.getContent()));
+    
+    Mockito.verify(datastoreRepository, Mockito.times(1))
+           .createRevisionEntry(Mockito.any(GitHubData.class));
   }
 
 }

--- a/src/test/java/com/google/graphgeckos/dashboard/github/GitHubJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/github/GitHubJsonTestInfo.java
@@ -1,7 +1,6 @@
 package com.google.graphgeckos.dashboard.github;
 
 import com.google.graphgeckos.dashboard.AbstractJsonTestInfo;
-import com.google.graphgeckos.dashboard.datatypes.GitHubData;
 
 /**
  * Represents input and expected output for a test. Used in {@see GitHubControllerTest}.

--- a/src/test/java/com/google/graphgeckos/dashboard/github/GitHubJsonTestInfo.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/github/GitHubJsonTestInfo.java
@@ -1,6 +1,7 @@
 package com.google.graphgeckos.dashboard.github;
 
 import com.google.graphgeckos.dashboard.AbstractJsonTestInfo;
+import com.google.graphgeckos.dashboard.datatypes.GitHubData;
 
 /**
  * Represents input and expected output for a test. Used in {@see GitHubControllerTest}.
@@ -13,23 +14,16 @@ public class GitHubJsonTestInfo extends AbstractJsonTestInfo {
   private String timestamp;
   private String repositoryLink;
 
-  /**
-   * {@inheritDoc}
-   */
   public GitHubJsonTestInfo(String testName) {
     super(testName);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   protected String getPath() {
     return "src/test/resources/jsons/";
   }
 
   /**
-   * {@inheritDoc}
    * Values come in the following order: branch, commit hash, timestamp, repository link.
    *
    * @param expected Lines of the expected output file for the test.


### PR DESCRIPTION
- Implemented absent functionality of the ```GitHubController```: the fetcher now adds the fetched information to the storage via an instance of DatastoreRepository.

- Added the corresponding test.