### PR TITLE
Safely Open Navigation Links in New Tab

### DIFF
--- a/src/main/webapp/components/Navigation.js
+++ b/src/main/webapp/components/Navigation.js
@@ -11,7 +11,8 @@ import {getField} from "./utils/getField";
 const NavigationItem = (props) => {
   return (
     <li>
-      <a href = {props.href}>{props.innerText}</a>
+      <a href={props.href}
+          target='_blank' rel='noopener noreferrer'>{props.innerText}</a>
     </li>
   );
 }


### PR DESCRIPTION
This PR adds two attributes that facilitate safe redirection when a user clicks on a link from navigation.

- <code>target _blank</code> opens the page in a new tab.
- <code>rel noopener noreferrer</code> is a security measure that is cited to [prevent newly opened tabs from modifying our original tab maliciously](https://support.detectify.com/support/solutions/articles/48001048981-external-links-using-target-blank).