### PR TITLE
Add Google Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,15 @@
     </dependency>
 
     <dependency>
-        <groupId>com.google.cloud.tools</groupId>
-        <artifactId>appengine-maven-plugin</artifactId>
-        <version>2.3.0</version>
+      <groupId>com.google.cloud.tools</groupId>
+      <artifactId>appengine-maven-plugin</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Add BOM for Guava, which we'll use to check for null arguments, instead of Objects.RequireNonNull. More details on [Preconditions Explained](https://github.com/google/guava/wiki/PreconditionsExplained)