### PR TITLE
Refactor Destructuring

### DIFF
--- a/src/main/webapp/components/BuildSnapshot.js
+++ b/src/main/webapp/components/BuildSnapshot.js
@@ -20,8 +20,11 @@ export const BuildSnapshot = (props) => {
   // and the indicator arrow on the Header should be facing downwards.
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const headerData = ({commitHash, description, repository, status} = props.buildData);
-  const trayData = ({builders, timestamp} = props.buildData);
+  const {builders, commitHash, description,
+      repository, status, timestamp} = props.buildData;
+
+  const headerData = {commitHash, description, repository, status};
+  const trayData = {builders, timestamp};
 
   return (
     <div className='build-snapshot'>


### PR DESCRIPTION
This PR changes the destructing method using in BuildSnapshot to destructure <code>props.buildData</code> once and explicitly create the new <code>headerData</code> and <code>trayData</code> objects.

#### Motivation for change
- The previous method seems to not be fully supported. Although it worked in console (chrome dev tools), it threw an error at runtime.
- No longer have to destructure buildData twice.