### PR TITLE
Update Prop Name to Align with Prop Expected by BuilderGrid

### DIFF
--- a/src/main/webapp/components/BuildSnapshot.js
+++ b/src/main/webapp/components/BuildSnapshot.js
@@ -79,7 +79,7 @@ const Tray = (props) => {
       <div className='tray-currentbot'>
         <span className='bot-display'>{builder.name}</span>
       </div>
-      <BuilderGrid onClick={selectBuilder} data={props.data.builders}/>
+      <BuilderGrid onClick={selectBuilder} builders={props.data.builders}/>
       <BuilderDataTable buildSteps={builder.buildSteps}/>
     </div>
   );


### PR DESCRIPTION
This PR fixes an <code>undefined</code> error thrown due to a mismatch in naming for props.