### PR TITLE
Add Key to Components Generated with Array.map

### DIFF
--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -37,7 +37,8 @@ export const BuildSnapshotContainer = React.memo((props) =>
 
     let content;
     if (data.length > 0) {
-      content = data.map(snapshot => <BuildSnapshot buildData={snapshot}/>);
+      content = data.map((snapshot, idx) => 
+          <BuildSnapshot key={idx} buildData={snapshot}/>);
     } else {
       content = <span className='loader'>
           No new revisions to display as of {new Date().toLocaleString()}.</span>;

--- a/src/main/webapp/components/BuilderDataTable.js
+++ b/src/main/webapp/components/BuilderDataTable.js
@@ -23,12 +23,12 @@ export const BuilderDataTable = props => {
   return (
     <table className='data-table'>
       <thead>
-        <tr>{HEADERS.map(header => <th>{header}</th>)}</tr>
+        <tr>{HEADERS.map((header, idx) => <th key={idx}>{header}</th>)}</tr>
       </thead>
       <tbody>
         {buildSteps.map(datapoint => 
           <tr>
-            {BUILD_STEP_FIELDS.map(field => <td>{datapoint[field]}</td>)}
+            {BUILD_STEP_FIELDS.map((field, idx) => <td key={idx}>{datapoint[field]}</td>)}
           </tr>
         )}
       </tbody>


### PR DESCRIPTION
To suppress the <code>react-no-key-warning</code>, this PR adds a key wherever <code>Array.map</code> is used to recursively generate React components.

[The React Documentation outlines why keys are necessary, and can have a huge performance boost when used correctly](https://reactjs.org/docs/reconciliation.html#recursing-on-children)