### PR TITLE
Add pagination functionality

### DIFF
--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -24,7 +24,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
     const SOURCE = `/builders/number=${NUMBER}/offset=${OFFSET}`;
 
     /**
-     * Moves pageNumber with a set increment
+     * Moves pageNumber with a set increment.
      *
      * @param increment is how many pages to jump over
      *     (negative values for going back)

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -13,7 +13,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
     const [data, setData] = React.useState([]);
 
     // Number of entries to be pulled. 20 seems reasonable enough.
-    // TODO: Add options for this number on paginationNavbar
+    // TODO: Add options for this number on paginationNavbar.
     const NUMBER = 20;
 
     // The starting point from which the entries are selected.

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -20,7 +20,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
     // Relative to the starting index.
     const OFFSET = NUMBER * pageNumber;
 
-    // The endpoint from where we get data from
+    // The endpoint from where we get data from.
     const SOURCE = `/builders/number=${NUMBER}/offset=${OFFSET}`;
 
     /**

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -9,18 +9,27 @@ import {BuildSnapshot} from "./BuildSnapshot";
  */
 export const BuildSnapshotContainer = React.memo((props) =>
   {
-    // Number of entries to be pulled.
-    // TODO: Determine true value for number of entries.
-    const NUMBER = 2;
+    const [pageNumber, setPageNumber] = React.useState(0);
+    const [data, setData] = React.useState([]);
+
+    // Number of entries to be pulled. 20 seems reasonable enough.
+    // TODO: Add options for this number on paginationNavbar
+    const NUMBER = 20;
 
     // The starting point from which the entries are selected.
     // Relative to the starting index.
-    // TODO: vary multiplier based on page number.
-    const OFFSET = NUMBER * 0;
+    const OFFSET = NUMBER * pageNumber;
 
+    // The endpoint from where we get data from
     const SOURCE = `/builders/number=${NUMBER}/offset=${OFFSET}`;
 
-    const [data, setData] = React.useState([]);
+    /**
+     * Moves pageNumber with a set increment
+     *
+     * @param increment is how many pages to jump over
+     *     (negative values for going back)
+     */ 
+    const changePage = (increment) => setPageNumber(pageNumber + increment);
 
     /**
      * Fetch data when component is mounted.
@@ -43,10 +52,27 @@ export const BuildSnapshotContainer = React.memo((props) =>
           No new revisions to display as of {new Date().toLocaleString()}.</span>;
     }
 
+    let hasPrev = pageNumber == 0;
+    let hasNext = data.length < NUMBER;
+
+    let paginationNavbar = 
+      <div className='pagination'>
+        <span className={`${hasPrev ? 'hiddenButton' : 'paginationButton'} prevPage`}
+              onClick={hasPrev ? null : () => changePage(-1)}></span>
+        <span className={`${hasNext ? 'hiddenButton' : 'paginationButton'} nextPage`}
+              onClick={hasNext ? null : () => changePage(1)}></span>
+        <span className='currentPage'>Page: {pageNumber}</span>
+      </div>;
+
     return (
-      <div id='build-snapshot-container'>
-        {content}
-      </div>
+      <>
+        <div id='build-snapshot-container'>
+          {content}
+        </div>
+        <div id='pagination-navbar'>
+          {paginationNavbar}
+        </div>
+      </>
     );
   }
 );

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -52,7 +52,7 @@ export const BuildSnapshotContainer = React.memo((props) =>
           No new revisions to display as of {new Date().toLocaleString()}.</span>;
     }
 
-    let hasPrev = pageNumber == 0;
+    let hasPrev = pageNumber === 0;
     let hasNext = data.length < NUMBER;
 
     let paginationNavbar = 

--- a/src/main/webapp/components/BuildSnapshotContainer.js
+++ b/src/main/webapp/components/BuildSnapshotContainer.js
@@ -66,10 +66,13 @@ export const BuildSnapshotContainer = React.memo((props) =>
 
     return (
       <>
+        <div id='pagination-navbar-top'>
+          {paginationNavbar}
+        </div>
         <div id='build-snapshot-container'>
           {content}
         </div>
-        <div id='pagination-navbar'>
+        <div id='pagination-navbar-bottom'>
           {paginationNavbar}
         </div>
       </>


### PR DESCRIPTION
This PR adds the structure needed for changing the pages shown on the front end. **This is done via 2 buttons "prevPage" and "nextPage", and a visual indicator of the current page number.**

Currently, each page has a fixed number of **20 build snapshots**, but the plan is for the user to be able to choose how many entries per page it wants. The styling will come in a later PR.