### PR TITLE
Add styling for pagination

### DIFF
--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -153,9 +153,6 @@ ul {
 /* Pagination Button Element when hidden */
 .hiddenButton {
   background: transparent;
-  border-width: 0 var(--button-size) var(--button-size) 0;
-  float: right;
-  padding: var(--button-size);
 }
 
 /* Pagination Button Element when visible */

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -4,10 +4,10 @@
 
 :root {
   --background: #0c0d25;
+  --button-size: .3125rem;
   --failed: #dc4f4f;
   --passed: #4fdc7f;
   --primary: white;
-  --button-size: .3125rem;
   font-size: 16px;
 }
 

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -148,3 +148,33 @@ ul {
   padding: 1rem 0;
   text-align: center;
 }
+
+.hiddenButton {
+  border: solid #333;
+  border-width: 0 5px 5px 0;
+  float: right;
+  padding: 5px;
+}
+
+.paginationButton {
+  border: solid white;
+  border-width: 0 5px 5px 0;
+  float: right;
+  padding: 5px;
+}
+
+.prevPage {
+  margin: 0 3rem 0 0;
+  transform: rotate(135deg);
+  -webkit-transform: rotate(135deg);
+}
+
+.nextPage {
+  margin: 0 -3rem 0 0;
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+}
+
+.currentPage {
+  font: 2rem normal 'Roboto' sans-serif;
+}

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -7,6 +7,7 @@
   --failed: #dc4f4f;
   --passed: #4fdc7f;
   --primary: white;
+  --button-size: .3125rem;
   font-size: 16px;
 }
 
@@ -143,32 +144,36 @@ ul {
   padding: 0.5rem;
 }
 
-/* Message Element in BuildSnapshot Container*/
+/* Message Element in BuildSnapshot Container */
 .loader {
   padding: 1rem 0;
   text-align: center;
 }
 
+/* Pagination Button Element when hidden */
 .hiddenButton {
-  border: solid #333;
-  border-width: 0 5px 5px 0;
+  background: transparent;
+  border-width: 0 var(--button-size) var(--button-size) 0;
   float: right;
-  padding: 5px;
+  padding: var(--button-size);
 }
 
+/* Pagination Button Element when visible */
 .paginationButton {
-  border: solid white;
-  border-width: 0 5px 5px 0;
+  border: solid var(--primary);
+  border-width: 0 var(--button-size) var(--button-size) 0;
   float: right;
-  padding: 5px;
+  padding: var(--button-size);
 }
 
+/* Proper rotation and position properties for the previous page button */
 .prevPage {
   margin: 0 3rem 0 0;
   transform: rotate(135deg);
   -webkit-transform: rotate(135deg);
 }
 
+/* Proper rotation and position properties for the next page button */
 .nextPage {
   margin: 0 -3rem 0 0;
   transform: rotate(-45deg);


### PR DESCRIPTION
Added styling for the pagination buttons, having the next and previous page buttons to the bottom right of the page, with a proper size for ease of use, and kept the page number to the left of the page. Colors for the buttons are greyed-out if the change cannot be made (user already on last/first page), while keeping them white if they are clickable.

![Screenshot 2020-09-22 at 19 29 38 - Display 2](https://user-images.githubusercontent.com/46264496/93910680-1d390d80-fd0a-11ea-851c-58546d83c8dd.png)
