### PR TITLE
Add Missing Key to Table and Stretch to fill Tray

### DIFF
--- a/src/main/webapp/components/BuilderDataTable.js
+++ b/src/main/webapp/components/BuilderDataTable.js
@@ -40,8 +40,8 @@ export const BuilderDataTable = props => {
         <tr>{HEADERS.map((header, idx) => <th key={idx}>{header}</th>)}</tr>
       </thead>
       <tbody>
-        {buildSteps.map(datapoint => 
-          <tr>
+        {buildSteps.map((datapoint, idx) =>
+          <tr key={idx}>
             {BUILD_STEP_FIELDS.map((field, idx) => <td key={idx}>{datapoint[field]}</td>)}
           </tr>
         )}

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -135,6 +135,7 @@ ul {
 .data-table {
   border-bottom-right-radius: 0.75rem;
   border-collapse: collapse;
+  height: 100%;
   overflow: hidden;
   text-align: center;
 }


### PR DESCRIPTION
- Update the styling to add key to elements generated with <code>Array.map</code> inside data table, similar to #191
- Stretch the data table to fill the tray by setting its <code>height</code> to 100%. 