### PR TITLE
Update DatastoreRepository Class JDoc

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -39,10 +39,8 @@ import org.springframework.stereotype.Repository;
 
 /**
  * A DataRepository implementation backed up by Google Datastore.
- * Each database entry is modeled by the {@link #BuildInfo BuildInfo} class.
- * The relevant fields for the database are:
- *    - Kind: "revision"
- *    - Key: commit hash
+ * Each database "revision" entry is modeled by the {@link #BuildInfo BuildInfo} class.
+ * Each database "index" entry is modeled by the {@link #BuilderIndex BuilderIndex} class.
  *
  * Useful links:
  * - https://googleapis.dev/java/google-cloud-datastore/latest/index.html


### PR DESCRIPTION
Changed documentation to reflect the new addition of "index" type entry, and removed an easily deprecable paragraph about relevant "revision" fields.