### PR TITLE
Add documentation to all DatastoreRepositoryTest tests.

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -39,10 +39,8 @@ import org.springframework.stereotype.Repository;
 
 /**
  * A DataRepository implementation backed up by Google Datastore.
- * Each database entry is modeled by the {@link #BuildInfo BuildInfo} class.
- * The relevant fields for the database are:
- *    - Kind: "revision"
- *    - Key: commit hash
+ * Each database "revision" entry is modeled by the {@link #BuildInfo BuildInfo} class.
+ * Each database "index" entry is modeled by the {@link #BuilderIndex BuilderIndex} class.
  *
  * Useful links:
  * - https://googleapis.dev/java/google-cloud-datastore/latest/index.html

--- a/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/storage/DatastoreRepositoryTests.java
@@ -37,7 +37,9 @@ public class DatastoreRepositoryTests {
   private LocalDatastoreHelper emulator = LocalDatastoreHelper.newBuilder().setConsistency(1.0)
                                                                            .setStoreOnDisk(false)
                                                                            .build();
-
+  /**
+   * Starts the GC Datastore emulator.
+   */
   public DatastoreRepositoryTests() throws IOException, InterruptedException {
     emulator.start();
   }
@@ -54,13 +56,20 @@ public class DatastoreRepositoryTests {
     return new BuildBotData(commitHash, "tester", new ArrayList<>(), BuilderStatus.PASSED);
   }
 
+  /**
+   * Resets the Datastore emulator to a blank state after each test.
+   */
   @After
   public void reset() throws IOException {
     emulator.reset();
   }
 
+  /**
+   * Tests if DatastoreRepository can create a new "revision" entry and then get it back intact.
+   * The creation should succeed, and the value retrieved should be equal to the one that was set.
+   */
   @Test
-  public void testValidAddition() throws IOException, InterruptedException{
+  public void testValidAddition() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
     Timestamp time = Timestamp.ofTimeMicroseconds(0);
     
@@ -68,8 +77,13 @@ public class DatastoreRepositoryTests {
     assertEquals(getDummyEntity("1", time), (storage.getRevisionEntry("1")));
   }
 
+  /**
+   * Tests if DatastoreRepository can create a new entry, update and get the updated entry back.
+   * The creation and update should succeed, and the value retrieved should be equal to the
+   * creation data + the update.
+   */
   @Test
-  public void testValidUpdate() throws IOException, InterruptedException {
+  public void testValidUpdate() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
     Timestamp time = Timestamp.ofTimeMicroseconds(0);
 
@@ -81,8 +95,12 @@ public class DatastoreRepositoryTests {
     assertEquals(dummy, storage.getRevisionEntry("1"));
   }
 
+  /**
+   * Tests that after deleting an entry there is no leftover entity with the same key.
+   * Both creation and deletion should succeed, and the get request should return null.
+   */
   @Test
-  public void testValidDeletion() throws IOException, InterruptedException {
+  public void testValidDeletion() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
     Timestamp time = Timestamp.ofTimeMicroseconds(0);
 
@@ -92,10 +110,10 @@ public class DatastoreRepositoryTests {
   }
 
   /**
-   * Tests the behaviour of add/update/get/delete requests on null data.
+   * Tests the behavior of all DatastoreRepository methods on null data. All should return NPE.
    */
   @Test
-  public void testRequestsNullData() throws IOException, InterruptedException {
+  public void testRequestsNullData() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     assertThrows(IllegalArgumentException.class, () -> {
@@ -127,8 +145,12 @@ public class DatastoreRepositoryTests {
     });
   }
 
+  /**
+   * Tests the behavior of DatastoreRepository when creating two entries with the same key.
+   * The first request should succeed, and the second one should fail.
+   */
   @Test
-  public void testAddingSameEntry() throws IOException, InterruptedException {
+  public void testAddingSameEntry() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
     Timestamp time = Timestamp.ofTimeMicroseconds(0);
 
@@ -136,32 +158,45 @@ public class DatastoreRepositoryTests {
     assertFalse(storage.createRevisionEntry(getDummyGitData("1", time)));
   }
 
+  /**
+   * Tests the behavior of DatastoreRepository when an update as attempted on an inexistent key.
+   * The request should fail.
+   */
   @Test
-  public void testUpdatingInexistentEntry() throws IOException, InterruptedException {
+  public void testUpdatingInexistentEntry() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     assertFalse(storage.updateRevisionEntry(getDummyUpdate("1")));
   }
 
+  /**
+   * Tests the behavior of DatastoreRepository when a get is attempted on an inexistent key.
+   * The request should return null.
+   */
   @Test
-  public void testGettingInexistentEntry() throws IOException, InterruptedException {
+  public void testGettingInexistentEntry() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     assertNull(storage.getRevisionEntry("1"));
   }
 
+  /**
+   * Tests the behavior of DatastoreRepository when a deletion is attempted on an inexistent key.
+   * The request should succeed.
+   */
   @Test
-  public void testDeletingInexistentEntry() throws IOException, InterruptedException {
+  public void testDeletingInexistentEntry() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     assertTrue(storage.deleteRevisionEntry("1"));
   }
 
   /**
-   * Test possible cases of the getLastRevisions query.
+   * Test the behavior of a getLastRevisionEntries query with no offset and enough data.
+   * The request should return the latest 3 entries, in a descending order.
    */
   @Test
-  public void testGetLastRevisionsRegularQuery() throws IOException, InterruptedException {
+  public void testGetLastRevisionsRegularQuery() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
     Timestamp time1 = Timestamp.ofTimeMicroseconds(1);
     Timestamp time2 = Timestamp.ofTimeMicroseconds(2);
@@ -182,8 +217,13 @@ public class DatastoreRepositoryTests {
     assertEquals(results.get(2), getDummyEntity("3", time3));
   }
 
+  /**
+   * Test the behavior of a getLastRevisionEntries query with an offset and enough data.
+   * The request should return the latest entries starting from the 3rd latest,
+   * in descending order.
+   */
   @Test
-  public void testGetLastRevisionsQueryOffset() throws IOException, InterruptedException {
+  public void testGetLastRevisionsQueryOffset() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
     Timestamp time1 = Timestamp.ofTimeMicroseconds(1);
     Timestamp time2 = Timestamp.ofTimeMicroseconds(2);
@@ -204,8 +244,13 @@ public class DatastoreRepositoryTests {
     assertEquals(results.get(2), getDummyEntity("1", time1));
   }
 
+  /**
+   * Test the behavior of a getLastRevisionEntries query with an offset and insufficient data.
+   * The request should return only 2 out of 3 requested entries, since entry #3 was deleted,
+   * and the first two were skipped.
+   */
   @Test
-  public void testGetLastRevisionsQueryAfterDeletion() throws IOException, InterruptedException {
+  public void testGetLastRevisionsQueryAfterDeletion() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
     Timestamp time1 = Timestamp.ofTimeMicroseconds(1);
     Timestamp time2 = Timestamp.ofTimeMicroseconds(2);
@@ -228,8 +273,12 @@ public class DatastoreRepositoryTests {
     assertEquals(results.get(1), getDummyEntity("1", time1));
   }
 
+  /**
+   * Tests if DatastoreRepository can create a new "index" entry and then get it back intact.
+   * The value retrieved should be the one that was set.
+   */
   @Test
-  public void testValidGetAndSetIndexRequests() throws IOException, InterruptedException {
+  public void testValidGetAndSetIndexRequests() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     storage.setBuildbotIndex("tester", 1000);
@@ -237,8 +286,12 @@ public class DatastoreRepositoryTests {
     assertEquals(1000, storage.getBuildbotIndex("tester"));
   }
 
+  /**
+   * Tests the behavior when a getBuildbotIndex is attempted for an unregistered buildbot.
+   * The request should throw {@link #BuildbotNotFoundException BuildbotNotFoundException}.
+   */
   @Test
-  public void testInvalidGetIndexRequest() throws IOException, InterruptedException {
+  public void testInvalidGetIndexRequest() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     assertThrows(BuildbotNotFoundException.class, () -> {
@@ -246,6 +299,10 @@ public class DatastoreRepositoryTests {
     });
   }
 
+  /**
+   * Tests the behavior when an index is updated with a lesser and equal value than
+   * the current one. Both updates should fail and throw an exception.
+   */
   @Test
   public void testInvalidSetIndexRequest() throws IOException, InterruptedException {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
@@ -261,8 +318,12 @@ public class DatastoreRepositoryTests {
     });
   }
 
+  /**
+   * Tests if registerNewBuildbot creates a proper "index" entry that can be retrieved.
+   * The value retrieved should be equal to the one registered.
+   */
   @Test
-  public void testValidRegistration() throws IOException, InterruptedException {
+  public void testValidRegistration() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     storage.registerNewBuildbot("test", 1);
@@ -270,8 +331,12 @@ public class DatastoreRepositoryTests {
     assertEquals(1, storage.getBuildbotIndex("test"));
   }
 
+  /**
+   * Tests if the same buildbot can be registered twice, the second time with a bigger index.
+   * The second registration should overwrite the previous one.
+   */
   @Test
-  public void testAlreadyRegisteredLargerIndex() throws IOException, InterruptedException {
+  public void testAlreadyRegisteredLargerIndex() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     storage.registerNewBuildbot("test", 1);
@@ -281,8 +346,12 @@ public class DatastoreRepositoryTests {
     assertEquals(3, storage.getBuildbotIndex("test"));
   }
 
+  /**
+   * Tests the behavior when the same buildbot is registered twice, with the same value.
+   * No exceptions should be thrown, and both registrations should succeed.
+   */
   @Test
-  public void testAlreadyRegisteredSameIndex() throws IOException, InterruptedException {
+  public void testAlreadyRegisteredSameIndex() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     storage.registerNewBuildbot("test", 1);
@@ -292,8 +361,12 @@ public class DatastoreRepositoryTests {
     assertEquals(1, storage.getBuildbotIndex("test"));
   }
 
+  /**
+   * Tests the behaviour when the same buildbot is registered twice, and the second value is
+   * smaller than the first one. The second registration should fail and throw an exception.
+   */
   @Test
-  public void testAlreadyRegisteredSmallerIndex() throws IOException, InterruptedException {
+  public void testAlreadyRegisteredSmallerIndex() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     storage.registerNewBuildbot("test", 3);
@@ -303,8 +376,12 @@ public class DatastoreRepositoryTests {
     });
   }
 
+  /**
+   * Tests the behaviour when a buildbot is registered for the first time with a negative index.
+   * The registration should fail and throw an exception.
+   */
     @Test
-  public void testFirstRegistrationNegative() throws IOException, InterruptedException {
+  public void testFirstRegistrationNegative() {
     DatastoreRepository storage = new DatastoreRepository(emulator.getOptions().getService());
 
     assertThrows(IllegalArgumentException.class, () -> {


### PR DESCRIPTION
Added explanations for all the tests. 

Also removed unnecessary `throws` clause from the tests as well, since it was a leftover from another version of the tests.