### PR TITLE
fix inverse logic in checkArgument

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -222,8 +222,8 @@ public class DatastoreRepository implements DataRepository {
 
     checkNotNull(associatedEntity, "no associated entity with the provided name");
 
-    checkArgument(newValue <= associatedEntity.getIndex(),
-                               "newValue cannot be lower than or equal the previous index");
+    checkArgument(newValue >= associatedEntity.getIndex(),
+                               "newValue cannot be lower than the previous index");
 
     associatedEntity.setIndex(newValue);
     storage.save(associatedEntity);


### PR DESCRIPTION
Preconditions.checkArgument(CONDITION) checks for the `CONDITION` to be true. While merging #199 I mistakenly accepted previous changes, which had the CONDITION to be false under normal circumstances. This PR fixes that mistake and allows 2 tests to pass.