### PR TITLE
Catch undefined error when accessing builder array

### DIFF
--- a/src/main/webapp/components/BuildSnapshot.js
+++ b/src/main/webapp/components/BuildSnapshot.js
@@ -94,12 +94,17 @@ const Tray = (props) => {
   const [selectedBuilder, selectBuilder] = React.useState(0);
   const builder = props.data.builders[selectedBuilder];
 
+  let builderName = "";
+  if (builder !== undefined) {
+    builderName = builder.name;
+  }
+
   if (props.isOpen !== true) { return null };
   return (
     <div className='snapshot-tray'>
       <span className='tray-timespan'>{props.data.timestamp}</span>
       <div className='tray-currentbot'>
-        <span className='bot-display'>{builder.name}</span>
+        <span className='bot-display'>{builderName}</span>
       </div>
       <BuilderGrid onClick={selectBuilder} builders={props.data.builders}/>
       <BuilderDataTable buildSteps={builder.buildSteps}/>


### PR DESCRIPTION
This PR integrates a fix for an error returned when accessing the builders array from the API. It seems the undefined case wasn't being checked before accessing a builder's name field.