### PR TITLE
add global revision status

### DIFF
--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
@@ -133,6 +133,9 @@ public class BuildInfo {
     this.builders = new ArrayList<>(builders);
   }
 
+  /**
+   * Adds a new builder to the builder list and recomputes the revision status.
+   */
   public void addBuilder(@NonNull BuildBotData update) {
     builders.add(update);
 

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
@@ -142,7 +142,7 @@ public class BuildInfo {
    * If there is no builder data, or all builder data are lost, the status will be {@code lost}.
    */
   void reanalyseStatus() {
-    boolean allPassed = false;
+    boolean hasPassed = false;
   
     for (BuildBotData builder : builders) {
       if (builder.getStatus() == BuilderStatus.FAILED) {
@@ -150,11 +150,11 @@ public class BuildInfo {
 
         return;
       } else if (builder.getStatus() == BuilderStatus.PASSED) {
-        allPassed = true;
+        hasPassed = true;
       }
     }
   
-    if (allPassed) {
+    if (hasPassed) {
       this.status = RevisionStatus.passed;
     } else {
       this.status = RevisionStatus.lost;

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/BuildInfo.java
@@ -135,13 +135,15 @@ public class BuildInfo {
 
   public void addBuilder(@NonNull BuildBotData update) {
     builders.add(update);
+
+    reanalyseStatus();
   }
 
   /**
    * Updates the {@code status} field according to all the aggregated builder statuses.
    * If there is no builder data, or all builder data are lost, the status will be {@code lost}.
    */
-  void reanalyseStatus() {
+  private void reanalyseStatus() {
     boolean hasPassed = false;
   
     for (BuildBotData builder : builders) {

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/RevisionStatus.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/RevisionStatus.java
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.graphgeckos.dashboard.datatypes;
+
+/**
+ * Represents global revision statuses.
+ */
+public enum RevisionStatus {
+  failed,
+  passed,
+  lost
+}

--- a/src/main/java/com/google/graphgeckos/dashboard/datatypes/RevisionStatus.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/datatypes/RevisionStatus.java
@@ -16,6 +16,8 @@ package com.google.graphgeckos.dashboard.datatypes;
 
 /**
  * Represents global revision statuses.
+ * 
+ * TODO: change to upperCase here and on the receiving front end part
  */
 public enum RevisionStatus {
   failed,

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -118,6 +118,9 @@ public class DatastoreRepository implements DataRepository {
       return false;
     }
 
+    associatedEntity.addBuilder(updateData);
+    associatedEntity.reanalyseStatus();
+
     try {
       storage.save(associatedEntity);
     } catch (DatastoreException e) {

--- a/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
+++ b/src/main/java/com/google/graphgeckos/dashboard/storage/DatastoreRepository.java
@@ -119,7 +119,6 @@ public class DatastoreRepository implements DataRepository {
     }
 
     associatedEntity.addBuilder(updateData);
-    associatedEntity.reanalyseStatus();
 
     try {
       storage.save(associatedEntity);

--- a/src/test/java/com/google/graphgeckos/dashboard/datatypes/BuildInfoTests.java
+++ b/src/test/java/com/google/graphgeckos/dashboard/datatypes/BuildInfoTests.java
@@ -1,0 +1,114 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.graphgeckos.dashboard.datatypes;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.Timestamp;
+import java.util.ArrayList;
+import org.junit.Test;
+
+public class BuildInfoTests {
+  private BuildInfo getDummyEntity() {
+    return new BuildInfo(new GitHubData("dummy", Timestamp.ofTimeMicroseconds(0), "test"));
+  }
+
+  private BuildBotData getDummyUpdate(BuilderStatus status) {
+    return new BuildBotData("dummy", "tester", new ArrayList<>(), status);
+  }
+
+  @Test
+  public void testDefaultStatus() {
+    BuildInfo dummy = getDummyEntity();
+
+    assertEquals(RevisionStatus.lost, dummy.getStatus());
+  }
+
+  @Test
+  public void testAllPassedStatus() {
+    BuildInfo dummy = getDummyEntity();
+
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.PASSED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.PASSED));
+
+    dummy.reanalyseStatus();
+
+    assertEquals(RevisionStatus.passed, dummy.getStatus());
+  }
+
+  @Test
+  public void testPassedAndLost() {
+    BuildInfo dummy = getDummyEntity();
+
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.LOST));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.PASSED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.LOST));
+
+    dummy.reanalyseStatus();
+
+    assertEquals(RevisionStatus.passed, dummy.getStatus());
+  }
+
+  @Test
+  public void testAllLost() {
+    BuildInfo dummy = getDummyEntity();
+
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.LOST));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.LOST));
+
+    dummy.reanalyseStatus();
+
+    assertEquals(RevisionStatus.lost, dummy.getStatus());
+  }
+
+  @Test
+  public void testPassedAndFailed() {
+    BuildInfo dummy = getDummyEntity();
+
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.PASSED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.FAILED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.PASSED));
+
+    dummy.reanalyseStatus();
+
+    assertEquals(RevisionStatus.failed, dummy.getStatus());
+  }
+
+  @Test
+  public void testAllFailed() {
+    BuildInfo dummy = getDummyEntity();
+
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.FAILED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.FAILED));
+
+    dummy.reanalyseStatus();
+
+    assertEquals(RevisionStatus.failed, dummy.getStatus());
+  }
+
+  @Test
+  public void testMixed() {
+    BuildInfo dummy = getDummyEntity();
+
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.FAILED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.PASSED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.PASSED));
+    dummy.addBuilder(getDummyUpdate(BuilderStatus.LOST));
+
+    dummy.reanalyseStatus();
+
+    assertEquals(RevisionStatus.failed, dummy.getStatus());
+  }
+}


### PR DESCRIPTION
All builder statuses were not aggregated, and thus the front end received no info regarding the overall status of the build, required for color coding it and the status field on the snapshot. This PR adds a new datatype used for that, and the logic inside BuildInfo.