### PR TITLE
Fix error due to timestamp format mismatch

### DIFF
--- a/src/main/webapp/components/BuildSnapshot.js
+++ b/src/main/webapp/components/BuildSnapshot.js
@@ -103,10 +103,15 @@ const Tray = (props) => {
     builderName = builder.name;
   }
 
+  const {timestamp} = props.data;
+  if (timestamp !== undefined) {
+    seconds = timestamp.seconds;
+  }
+
   if (props.isOpen !== true) { return null };
   return (
     <div className='snapshot-tray'>
-      <span className='tray-timespan'>{props.data.timestamp}</span>
+      <span className='tray-timespan'>{seconds}</span>
       <div className='tray-currentbot'>
         <span className='bot-display'>{builderName}</span>
       </div>


### PR DESCRIPTION
This PR fixes an error that arises due to formatting difference between how our timestamps are stored in our GCP datastore and how they are expected on the frontend. The frontend expected a string where it got a frontend, causing an error since React cannot render objects directly. 